### PR TITLE
Possible fix: need for changing patch number for azure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ SET( ${PROJECT_NAME}_Variant "Full" ) # the particular variant of CaPTk (Full/Ne
 
 SET( PROJECT_VERSION_MAJOR 1 )
 SET( PROJECT_VERSION_MINOR 7 )
-SET( PROJECT_VERSION_PATCH 7.nonRelease.20200204 )
+SET( PROJECT_VERSION_PATCH 7.nonRelease )
 SET( PROJECT_VERSION_TWEAK )
 
 # Configure CCache if available

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -609,9 +609,11 @@ jobs:
       displayName: 'Performing the Tests'
 
     - bash: |
+        git_hash=$(git rev-parse --verify HEAD) # of the last commit
         cd bin
 
-        version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)
+        # Append git commit hash to the version. This way devs won't have to change the patch number on PRs
+        version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)_${git_hash}
 
         sudo rm -rf CaPTk_$version.app/Contents/Resources/bin/ITK-SNAP.app
 
@@ -630,9 +632,11 @@ jobs:
 
 
     - bash: |
+        git_hash=$(git rev-parse --verify HEAD) # of the last commit
         cd bin
 
-        version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)
+        # Append git commit hash to the version. This way devs won't have to change the patch number on PRs
+        version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)_${git_hash}
         pkgname="_Installer"
         pkgname="$version$pkgname"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -615,7 +615,7 @@ jobs:
         cd bin
         version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)
         ### In nonRelease builds
-        ### append git commit hash to the version. 
+        ### append date and git commit hash to the version. 
         ### This way devs won't have to change the patch number on PRs
         if [[ $version == *"nonRelease"* ]]; then
             version=${version}_${date}_${git_hash}
@@ -645,15 +645,13 @@ jobs:
         cd bin
         version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)
         ### In nonRelease builds
-        ### append git commit hash to the version. 
+        ### append date and git commit hash to the version. 
         ### This way devs won't have to change the patch number on PRs
         if [[ $version == *"nonRelease"* ]]; then
             version=${version}_${date}_${git_hash}
         fi
 
 
-        # Append git commit hash to the version. This way devs won't have to change the patch number on PRs
-        version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)_${git_hash}
         pkgname="_Installer"
         pkgname="$version$pkgname"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -610,7 +610,7 @@ jobs:
 
     - bash: |
         git_hash=$(git rev-parse --verify HEAD) # of the last commit
-        date=$(date '+%Y.%m.%d')                        # date in "YYYY.mm.dd" form
+        date=$(date '+%Y.%m.%d')                # date in "YYYY.mm.dd" form
 
         cd bin
         version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)
@@ -640,7 +640,7 @@ jobs:
 
     - bash: |
         git_hash=$(git rev-parse --verify HEAD) # of the last commit
-        date=$(date '+%Y.%m.%d')                        # date in "YYYY.mm.dd" form
+        date=$(date '+%Y.%m.%d')                # date in "YYYY.mm.dd" form
 
         cd bin
         version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -610,10 +610,17 @@ jobs:
 
     - bash: |
         git_hash=$(git rev-parse --verify HEAD) # of the last commit
-        cd bin
+        date=$(date '+%Y.%m.%d')                        # date in "YYYY.mm.dd" form
 
-        # Append git commit hash to the version. This way devs won't have to change the patch number on PRs
-        version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)_${git_hash}
+        cd bin
+        version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)
+        ### In nonRelease builds
+        ### append git commit hash to the version. 
+        ### This way devs won't have to change the patch number on PRs
+        if [[ $version == *"nonRelease"* ]]; then
+            version=${version}_${date}_${git_hash}
+        fi
+
 
         sudo rm -rf CaPTk_$version.app/Contents/Resources/bin/ITK-SNAP.app
 
@@ -633,7 +640,17 @@ jobs:
 
     - bash: |
         git_hash=$(git rev-parse --verify HEAD) # of the last commit
+        date=$(date '+%Y.%m.%d')                        # date in "YYYY.mm.dd" form
+
         cd bin
+        version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)
+        ### In nonRelease builds
+        ### append git commit hash to the version. 
+        ### This way devs won't have to change the patch number on PRs
+        if [[ $version == *"nonRelease"* ]]; then
+            version=${version}_${date}_${git_hash}
+        fi
+
 
         # Append git commit hash to the version. This way devs won't have to change the patch number on PRs
         version=$(grep -i -e "project_version:*" CMakeCache.txt | cut -c24-)_${git_hash}


### PR DESCRIPTION
- ⚠️ This is untested and I'm not exactly sure how to test it!! (paging @PhucNgo1711 @sarthakpati )
- Only on azure, append the commit hash to the project version. That way it's always unique without the need for developers to manually change it. 
- The local builds outside of azure remain unaffected from this

Potential pitfalls:
- Ugly package release names on azure?
- [CBICA/dcmqi](https://github.com/CBICA/dcmqi/blob/master/azure-pipelines.yml) has a similar azure-pipelines.yml that I'm not sure if it needs to change too
- There is a "change" to ```src/applications/Utilities/dcmqi``` from my PR that was not triggered by me intentionally. Maybe that's how submodules work, but I've never noticed it before. 