### PR TITLE
Add scheduled nightly build, NITRC upload only on schedule or manually run

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,11 @@
+# Schedule a build for every midnight Eastern time. This is visible to the pipeline as Build.Reason
+schedules:
+- cron: "0 4 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - master
+
 trigger:
   batch: true
   branches:
@@ -943,7 +951,7 @@ jobs:
         overwrite: true
         continueOnError: true
       displayName: Uploading to NITRC
-      condition: eq(variables['Build.DefinitionName'], 'CBICA.CaPTk')
+      condition: and( eq(variables['Build.DefinitionName'], 'CBICA.CaPTk'), or( eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'Schedule')) )
 
 - job: 'Linux_SelfHost'
   displayName: "Self-hosted agent on Ubuntu 16.04"
@@ -1118,7 +1126,7 @@ jobs:
         overwrite: true
         continueOnError: true
       displayName: Uploading to NITRC 
-      condition: eq(variables['Build.DefinitionName'], 'CBICA.CaPTk')
+      condition: and( eq(variables['Build.DefinitionName'], 'CBICA.CaPTk'), or( eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'Schedule')) )
 
 - job: 'macOS_SelfHost'
   displayName: "Self-hosted agent on macOS 10.14"
@@ -1303,4 +1311,4 @@ jobs:
         overwrite: true
         continueOnError: true
       displayName: Uploading to NITRC
-      condition: eq(variables['Build.DefinitionName'], 'CBICA.CaPTk')
+      condition: and( eq(variables['Build.DefinitionName'], 'CBICA.CaPTk'), or( eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'Schedule')) )


### PR DESCRIPTION
This PR includes azure pipelines changes.
A full build is now scheduled at 12:00 midnight, Eastern time, every night. This will be queued up at that time every night, but as far as I know will not interrupt existing runs. 

I changed the conditions on uploading to NITRC. Now, this will only happen if the build pipeline was caused by the nightly build scheduler or if the pipeline was run manually from Azure, in addition to the previous conditions. This will not occur for every PR. This step should appear as cancelled or skipped on PR-initiated builds. This change should save us a significant amount of time on the Linux build that was bottlenecking us for merging PRs.
