### PR TITLE
Fix "about" window oddness

### DIFF
--- a/src/view/gui/fHelpTutorial.cpp
+++ b/src/view/gui/fHelpTutorial.cpp
@@ -58,9 +58,9 @@ fHelpTutorial::fHelpTutorial()
 #if CAPTK_PACKAGE_PROJECT
   m_docDir = cbica::normPath(m_dataDir + "/../share/doc/");
 #else
-  m_docDir = std::string(PROJECT_SOURCE_DIR) + "../docs/html/";
+  m_docDir = std::string(PROJECT_SOURCE_DIR) + "docs/";
 #endif
-  m_helpFileFullPath = m_docDir + "/1_credits.html";
+  m_helpFileFullPath = m_docDir + "1_credits.html";
 
   QHBoxLayout *toolbar = new QHBoxLayout();
 
@@ -76,7 +76,7 @@ fHelpTutorial::fHelpTutorial()
 
   // m_webView = new QWebView();
   // NEW CHANGES
-  m_webView = new QWebEngineView();
+  m_webView = new QWebEngineView(this);
 
   //! we want to let the webpage take the max space
     //! this also makes sure that the labels do not get 
@@ -172,4 +172,10 @@ void fHelpTutorial::SetZoom(int zoomValue)
       this->zoomSlider->blockSignals(false);
     }
   }
+}
+
+void fHelpTutorial::showEvent(QShowEvent* event)
+{
+	this->m_webView->reload();
+
 }

--- a/src/view/gui/fHelpTutorial.cpp
+++ b/src/view/gui/fHelpTutorial.cpp
@@ -56,11 +56,11 @@ fHelpTutorial::fHelpTutorial()
 
   m_dataDir = getCaPTkDataDir();
 #if CAPTK_PACKAGE_PROJECT
-  m_docDir = cbica::normPath(m_dataDir + "/../share/doc/");
+  m_docDir = cbica::normPath(m_dataDir + "/../share/doc");
 #else
-  m_docDir = std::string(PROJECT_SOURCE_DIR) + "docs/";
+  m_docDir = std::string(PROJECT_SOURCE_DIR) + "docs";
 #endif
-  m_helpFileFullPath = m_docDir + "1_credits.html";
+  m_helpFileFullPath = m_docDir + "/1_credits.html";
 
   QHBoxLayout *toolbar = new QHBoxLayout();
 
@@ -176,6 +176,7 @@ void fHelpTutorial::SetZoom(int zoomValue)
 
 void fHelpTutorial::showEvent(QShowEvent* event)
 {
+	// ensure content reload when showing
 	this->m_webView->reload();
 
 }

--- a/src/view/gui/fHelpTutorial.h
+++ b/src/view/gui/fHelpTutorial.h
@@ -51,6 +51,9 @@ protected:
 	//! zoom to value
 	void SetZoom(int zoomValue);
 
+	// override dialog event to reload on show 
+	void showEvent(QShowEvent* event);
+
 signals:
 
 void skipTutorialOnNextRun(bool flag);

--- a/src/view/gui/fHelpTutorial.h
+++ b/src/view/gui/fHelpTutorial.h
@@ -51,7 +51,7 @@ protected:
 	//! zoom to value
 	void SetZoom(int zoomValue);
 
-	// override dialog event to reload on show 
+	// override dialog show event to make sure content is displayed 
 	void showEvent(QShowEvent* event);
 
 signals:

--- a/src/view/gui/fMainWindow.cpp
+++ b/src/view/gui/fMainWindow.cpp
@@ -1124,9 +1124,9 @@ std::string fMainWindow::ConversionFrom2Dto3D(const std::string &fileName)
 
 void fMainWindow::about()
 {
-#if CAPTK_PACKAGE_PROJECT
-  mHelpTutorial.exec();
-#endif
+//#if CAPTK_PACKAGE_PROJECT
+  mHelpTutorial.show();
+//#endif
 }
 
 void fMainWindow::help_Interactions()


### PR DESCRIPTION
Fixes issue #524 

I overrode the showEvent to reload the "about" page content. I also made the about window a "show" rather than "exec" since it doesn't really need to be modal. I also parented the WebEngineView to the dialog itself. This worked to alleviate the problem described in the issue for me on Windows. 

Edit: By the way, I tested this with the zoom functionality on the dialog and it seems to be preserved.

This PR should create the build artifacts we can use to test if this fix works for @MarkBergman-cbica. Or, if preferred, we can merge this in before the next alpha/beta and test it then. Since this issue is finicky and only occurs on specific machines, it'd be best if someone else who can reproduce this issue tests it. 