### PR TITLE
Add first-run OpenGL warning to the GUI

### DIFF
--- a/src/CaPTk.cxx
+++ b/src/CaPTk.cxx
@@ -210,9 +210,9 @@ int main(int argc, char** argv)
       return EXIT_FAILURE;
 #else // Attempt software rendering on non-Windows platforms, warn user 
       cbica::setEnvironmentVariable("QT_OPENGL", "software");
-	  std::string msg = "WARNING: Trying to run CaPTk GUI using software rendering - this might not work on all systems and in those cases, only the CLI will be available.\n";
-	  std::cerr << msg;
-	  ShowErrorMessage(msg);
+	  std::string softwareRenderingMsg = "WARNING: Trying to run CaPTk GUI using software rendering - this might not work on all systems and in those cases, only the CLI will be available.\n";
+	  std::cerr << softwareRenderingMsg;
+	  ShowErrorMessage(softwareRenderingMsg);
 #endif
     }
     else

--- a/src/CaPTk.cxx
+++ b/src/CaPTk.cxx
@@ -183,7 +183,6 @@ int main(int argc, char** argv)
   //cbica::setEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH", captk_currentApplicationPath + "/platforms");
   //cbica::setEnvironmentVariable("QT_OPENGL", "software");
 
-  bool alertNoCompatibleOpenGL = false; 
 
   // starting the OpenGL version checking 
   const std::string openGLVersionCheckFile = loggerFolderBase + "openglVersionCheck.txt";
@@ -202,15 +201,18 @@ int main(int argc, char** argv)
       std::string msg = "A working 3.2 version of OpenGL was not found in your hardware/software combination; consequently, CaPTk's GUI will not work; all CLIs will work as expected.\n\n";
       msg += "\tOpenGL Version : " + checker.version + "\n";
       msg += "\tOpenGL Renderer: " + checker.renderer + "\n";
-      msg += "\tOpenGL Vendor  : " + checker.vendor;
-	  alertNoCompatibleOpenGL = true;
+      msg += "\tOpenGL Vendor  : " + checker.vendor + "\n\n";
+	  msg += "Please install OpenGL version 3.2 or greater, or use the command line interface to run CaPTk.";
+	  msg += "\n\nCheck the documentation for details.";
+	  ShowErrorMessage(msg);
 #if WIN32
-      ShowErrorMessage(msg);
       cbica::sleep(1000);
       return EXIT_FAILURE;
-#else
+#else // Attempt software rendering on non-Windows platforms, warn user 
       cbica::setEnvironmentVariable("QT_OPENGL", "software");
-      std::cerr << "WARNING: Trying to run CaPTk GUI using software rendering - this might not work on all systems and in those cases, only the CLI will be available.\n";
+	  std::string msg = "WARNING: Trying to run CaPTk GUI using software rendering - this might not work on all systems and in those cases, only the CLI will be available.\n";
+	  std::cerr << msg;
+	  ShowErrorMessage(msg);
 #endif
     }
     else
@@ -329,16 +331,6 @@ int main(int argc, char** argv)
     // auto rec = QApplication::desktop()->screenGeometry();
     // std::cout << "Detected Size: " << rec.width() << "x" << rec.height() << "\n";
     window.about();
-  }
-
-  // Display missing/incompatible OpenGL error on first run 
-  if (alertNoCompatibleOpenGL)
-  {
-	  QMessageBox openGLWarningBox(QMessageBox::Warning, "No Compatible OpenGL Found", 
-		  "CaPTk failed to find a compatible version of OpenGL. The graphical user interface may not function correctly."
-		  " Please install OpenGL version 3.2 or greater, or use the command line interface to run CaPTk."
-		  "\n\nCheck the documentation for details.");
-	  openGLWarningBox.exec(); // Make sure it's acknowledged!
   }
 
 

--- a/src/CaPTk.cxx
+++ b/src/CaPTk.cxx
@@ -183,6 +183,8 @@ int main(int argc, char** argv)
   //cbica::setEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH", captk_currentApplicationPath + "/platforms");
   //cbica::setEnvironmentVariable("QT_OPENGL", "software");
 
+  bool alertNoCompatibleOpenGL = false; 
+
   // starting the OpenGL version checking 
   const std::string openGLVersionCheckFile = loggerFolderBase + "openglVersionCheck.txt";
   if (!cbica::isFile(openGLVersionCheckFile))
@@ -195,13 +197,13 @@ int main(int argc, char** argv)
 #else
     CheckOpenGLVersion checker;
 #endif
-
     if (!checker.hasVersion_3_2())
     {
       std::string msg = "A working 3.2 version of OpenGL was not found in your hardware/software combination; consequently, CaPTk's GUI will not work; all CLIs will work as expected.\n\n";
       msg += "\tOpenGL Version : " + checker.version + "\n";
       msg += "\tOpenGL Renderer: " + checker.renderer + "\n";
       msg += "\tOpenGL Vendor  : " + checker.vendor;
+	  alertNoCompatibleOpenGL = true;
 #if WIN32
       ShowErrorMessage(msg);
       cbica::sleep(1000);
@@ -327,6 +329,15 @@ int main(int argc, char** argv)
     // auto rec = QApplication::desktop()->screenGeometry();
     // std::cout << "Detected Size: " << rec.width() << "x" << rec.height() << "\n";
     window.about();
+  }
+
+  // Display missing/incompatible OpenGL error on first run 
+  if (alertNoCompatibleOpenGL)
+  {
+	  QMessageBox openGLWarningBox(QMessageBox::Warning, "No Compatible OpenGL Found", 
+		  "CaPTk failed to find a compatible version of OpenGL.  The graphical user interface may not function correctly."
+		  " Please install OpenGL version 3.2 or greater, or use the command line interface to run CaPTk.");
+	  openGLWarningBox.exec(); // Make sure it's acknowledged!
   }
 
 

--- a/src/CaPTk.cxx
+++ b/src/CaPTk.cxx
@@ -335,7 +335,7 @@ int main(int argc, char** argv)
   if (alertNoCompatibleOpenGL)
   {
 	  QMessageBox openGLWarningBox(QMessageBox::Warning, "No Compatible OpenGL Found", 
-		  "CaPTk failed to find a compatible version of OpenGL.  The graphical user interface may not function correctly."
+		  "CaPTk failed to find a compatible version of OpenGL. The graphical user interface may not function correctly."
 		  " Please install OpenGL version 3.2 or greater, or use the command line interface to run CaPTk."
 		  "\n\nCheck the documentation for details.");
 	  openGLWarningBox.exec(); // Make sure it's acknowledged!

--- a/src/CaPTk.cxx
+++ b/src/CaPTk.cxx
@@ -336,7 +336,8 @@ int main(int argc, char** argv)
   {
 	  QMessageBox openGLWarningBox(QMessageBox::Warning, "No Compatible OpenGL Found", 
 		  "CaPTk failed to find a compatible version of OpenGL.  The graphical user interface may not function correctly."
-		  " Please install OpenGL version 3.2 or greater, or use the command line interface to run CaPTk.");
+		  " Please install OpenGL version 3.2 or greater, or use the command line interface to run CaPTk."
+		  "\n\n Check the documentation for details.");
 	  openGLWarningBox.exec(); // Make sure it's acknowledged!
   }
 

--- a/src/CaPTk.cxx
+++ b/src/CaPTk.cxx
@@ -337,7 +337,7 @@ int main(int argc, char** argv)
 	  QMessageBox openGLWarningBox(QMessageBox::Warning, "No Compatible OpenGL Found", 
 		  "CaPTk failed to find a compatible version of OpenGL.  The graphical user interface may not function correctly."
 		  " Please install OpenGL version 3.2 or greater, or use the command line interface to run CaPTk."
-		  "\n\n Check the documentation for details.");
+		  "\n\nCheck the documentation for details.");
 	  openGLWarningBox.exec(); // Make sure it's acknowledged!
   }
 


### PR DESCRIPTION
Fixes #863

This PR adds a flag to the first-time OpenGL checking so that users running the GUI will also get a visible warning that must be acknowledged. It is modal for this reason. It asks the user to install OpenGL >= 3.2. However, this check is only performed once, as in the current mechanism. 

The current code outputs an error to std::cerr so CLI users already should see this.