### PR TITLE
help Linux pick up built documentation on Azure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,10 +703,8 @@ IF( NOT BUILD_DOCUMENTATION_ONLY )
 	  # TODO: Figure out how to set properties on files only present after configuration
 	  FILE(GLOB ALL_DOC_FILES_BASE "${PROJECT_BINARY_DIR}/docs_sources/html/*.*")
       FOREACH(docFiles ${ALL_DOC_FILES_BASE})
-        IF (APPLE)
-          SET_SOURCE_FILES_PROPERTIES(${docFiles} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/share/doc)
-          SET(META_FILES_TO_INCLUDE ${META_FILES_TO_INCLUDE} ${docFiles})
-        ENDIF()
+        SET_SOURCE_FILES_PROPERTIES(${docFiles} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/share/doc)
+        SET(META_FILES_TO_INCLUDE ${META_FILES_TO_INCLUDE} ${docFiles})
       ENDFOREACH()  
 	ELSE() # Windows or Linux
       # Need to install the directory to pick up files that are not present at configure time (for CI/Azure)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,16 +699,19 @@ IF( NOT BUILD_DOCUMENTATION_ONLY )
 
   SET(META_FILES_TO_INCLUDE "") # used for Apple package
   #IF( BUILD_DOCUMENTATION )
-    FILE(GLOB ALL_DOC_FILES_BASE "${PROJECT_BINARY_DIR}/docs_sources/html/*.*")
-    FOREACH(docFiles ${ALL_DOC_FILES_BASE})
-      IF (APPLE)
-        SET_SOURCE_FILES_PROPERTIES(${docFiles} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/share/doc)
-        SET(META_FILES_TO_INCLUDE ${META_FILES_TO_INCLUDE} ${docFiles})
-      ELSE()
-        INSTALL(FILES "${docFiles}" DESTINATION share/doc)
-      ENDIF()
-    ENDFOREACH()
-    #INSTALL( DIRECTORY ${PROJECT_BINARY_DIR}/docs_sources/html DESTINATION share/doc )
+	IF (APPLE) 
+	  # TODO: Figure out how to set properties on files only present after configuration
+	  FILE(GLOB ALL_DOC_FILES_BASE "${PROJECT_BINARY_DIR}/docs_sources/html/*.*")
+      FOREACH(docFiles ${ALL_DOC_FILES_BASE})
+        IF (APPLE)
+          SET_SOURCE_FILES_PROPERTIES(${docFiles} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/share/doc)
+          SET(META_FILES_TO_INCLUDE ${META_FILES_TO_INCLUDE} ${docFiles})
+        ENDIF()
+      ENDFOREACH()  
+	ELSE() # Windows or Linux
+      # Need to install the directory to pick up files that are not present at configure time (for CI/Azure)
+      INSTALL( DIRECTORY ${PROJECT_BINARY_DIR}/docs_sources/html/ DESTINATION share/doc )
+	ENDIF()
   #ENDIF()
 
   # ensure all licenses are in the package

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -527,11 +527,6 @@ jobs:
         # export PKG_COPY_QT_LIBS=1
         ./scripts/captk-pkg
 
-        rm -rf src
-        rm -rf docs*
-
-        rm -rf scripts
-
         mv *_Installer.* $(Build.ArtifactStagingDirectory)
 
         rm -rf bin


### PR DESCRIPTION
Some source-tree trimming was occurring in azure pipelines.yml, presumably to save space. But some of the trimming ended up being considered an unstaged change to the git repo and seemed to be unnecessary.
 This was ONLY happening on the ubuntu build agent (the VM on crete), but as a result was getting propagated to the Linux packages distributed via NITRC, etc. This may be why this issue was so weird to replicate...

Therefore this may end up fixing issues #524 (the later comments by Mark), as well as #1204. I'm going to try the build artifact before saying for sure.
EDIT: It didn't. However I looked at the CMake part of this and saw that the Install was being called on globbed files at configure-time. Therefore, if any of the doc files weren't present at configure time (as it was on the ubuntu agent: they weren't built yet!), they were not getting installed at install-time. Marking the directory for install, rather than the individual globbed files, fixes this so I just moved that behavior out of the check for Mac. We haven't gotten a report of this on Mac yet but it could be that this issue exists and persists on Mac, we'll see.

Still testing this on the Azure builds. Consequently this is a draft PR. I'll ping you guys when this can be merged in.
