### PR TITLE
make only PRs to master trigger a master build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ trigger:
 # 20200312: apparently this is now explicitly required for azure
 pr:
   branches:
-    include: ['*']
+    include: ['master']
 
 jobs:
 - job: 'WindowsBuild'


### PR DESCRIPTION
Changes azure-pipelines.yml on master to only trigger the build agent pipeline if a PR is to master. Now the CBICA.CaPTk pipeline on Azure runs from this file, while the CBICA.CaPTk_DecoupleApps pipeline will run from the one on the decoupleApps branch.

This change will eliminate our redundant builds and therefore decrease the time we spend waiting on the self-hosted agents.
