### PR TITLE
Change GUI BiasCorrection to avoid orientation weirdness

### DIFF
--- a/src/applications/Preprocessing/src/Preprocessing.cxx
+++ b/src/applications/Preprocessing/src/Preprocessing.cxx
@@ -684,7 +684,7 @@ int main(int argc, char** argv)
   parser.addOptionalParameter("nB", "nBiasBins", cbica::Parameter::INTEGER, "N.A.", "If no mask is specified, N3/N4 bias correction makes one using Otsu", "This parameter specifies the number of histogram bins for Otsu", "Defaults to " + std::to_string(bias_otsuBins));
   parser.addOptionalParameter("nFL", "nFittingLevels", cbica::Parameter::INTEGER, "N.A.", "The number of fitting levels to use for bias correction", "Defaults to " + std::to_string(bias_fittingLevels));
   parser.addOptionalParameter("nMI", "nMaxIterations", cbica::Parameter::INTEGER, "N.A.", "The maximum number of iterations for bias correction (only works for N3)", "Defaults to " + std::to_string(bias_maxIterations));
-  parser.addOptionalParameter("nFWHM", "nFullWidthHalfMaximum", cbica::Parameter::INTEGER, "N.A.", "Set the full-width-at-half-maximum value for bias correction", "Defaults to " + std::to_string(bias_fwhm));
+  parser.addOptionalParameter("nFWHM", "nFullWidthHalfMaximum", cbica::Parameter::FLOAT, "N.A.", "Set the full-width-at-half-maximum value for bias correction", "Defaults to " + std::to_string(bias_fwhm));
   parser.addOptionalParameter("ss", "susanSmooth", cbica::Parameter::STRING, "N.A.", "Susan smoothing of an image");
   parser.addOptionalParameter("ssS", "susanSigma", cbica::Parameter::FLOAT, "N.A.", "Susan smoothing Sigma", "Defaults to " + std::to_string(ssSigma));
   parser.addOptionalParameter("ssR", "susanRadius", cbica::Parameter::INTEGER, "N.A.", "Susan smoothing Radius", "Defaults to " + std::to_string(ssRadius));

--- a/src/view/gui/fMainWindow.cpp
+++ b/src/view/gui/fMainWindow.cpp
@@ -7431,92 +7431,54 @@ void fMainWindow::CallBiasCorrection(const std::string correctionType, QString s
     auto currentImage = mSlicerManagers[index]->mITKImage;
     auto maskImg = getMaskImage();
 
-    BiasCorrection biasCorrector;
+    auto tempDir = cbica::createTemporaryDirectory();
+    // saving to temp file and calling the CLI to avoid GUI orientation-fix weirdness
+    auto tempFilename = tempDir + "/TEMP_CAPTK_BIASCORRECTION.nii.gz";
+    SaveImage_withFile(index, QString::fromStdString(tempFilename));
 
-    if (currentImage->GetLargestPossibleRegion().GetSize()[2] == 1)
+    QString executableExt = "";
+#ifdef _WIN32
+    executableExt = ".exe";
+#endif
+    QString preprocessingExecutablePath = QApplication::applicationDirPath();
+    preprocessingExecutablePath += "/";
+#ifdef __APPLE__
+    preprocessingExecutablePath += "../Resources/bin/";
+#endif
+    preprocessingExecutablePath += "Preprocessing";
+    preprocessingExecutablePath += executableExt;
+
+    QStringList argsToBiasCorrection;
+    argsToBiasCorrection.append("-i " + QString::fromStdString(cbica::normPath(tempFilename)));
+    argsToBiasCorrection.append("-o " + saveFileName);
+    argsToBiasCorrection.append("-nS " + QString::number(bias_splineOrder));
+    argsToBiasCorrection.append("-nF " + QString::number(bias_filterNoise));
+    argsToBiasCorrection.append("-nB " + QString::number(bias_otsuBins));
+    argsToBiasCorrection.append("-nFL " + QString::number(bias_fittingLevels));
+    argsToBiasCorrection.append("-nMI " + QString::number(bias_maxIterations));
+    argsToBiasCorrection.append("-nFWHM " + QString::number(bias_fwhm));
+    argsToBiasCorrection.append("-" + QString::fromStdString(correctionType).toLower()); // note no space between - and type
+
+    updateProgress(5, "Bias correction in process");
+    int biascorrection_result = startExternalProcess(preprocessingExecutablePath, argsToBiasCorrection);
+    
+    if (biascorrection_result != 0 )
     {
-      // this is actually a 2D image which has been loaded as a 3D image with a single slize in z-direction
-      cbica::Logging(loggerFile, "2D Image detected, doing conversion and then passing into FE module");
-      using ImageTypeFloat2D = itk::Image< float, 2 >;
-      ImageTypeFloat2D::Pointer image_2d;
-
-      ImageTypeFloat3D::IndexType regionIndex;
-      regionIndex.Fill(0);
-      auto regionSize = currentImage->GetLargestPossibleRegion().GetSize();
-      regionSize[2] = 0; // only 2D image is needed
-      auto extractor = itk::ExtractImageFilter< ImageTypeFloat3D, ImageTypeFloat2D >::New();
-      ImageTypeFloat3D::RegionType desiredRegion(regionIndex, regionSize);
-      extractor->SetExtractionRegion(desiredRegion);
-      extractor->SetInput(currentImage);
-      extractor->SetDirectionCollapseToIdentity();
-      extractor->Update();
-      image_2d = extractor->GetOutput();
-      image_2d->DisconnectPipeline();
-
-      auto extractor_mask = itk::ExtractImageFilter< ImageTypeFloat3D, ImageTypeFloat2D >::New();
-      extractor_mask->SetExtractionRegion(desiredRegion);
-      extractor_mask->SetInput(maskImg);
-      extractor_mask->SetDirectionCollapseToIdentity();
-      extractor_mask->Update();
-      auto mask2D = extractor_mask->GetOutput();
-      //mask2D->DisconnectPipeline();
-
-      updateProgress(5, "Bias correction in process");
-
-      auto outputImage = biasCorrector.Run<ImageTypeFloat2D>(correctionType,
-        image_2d,
-        bias_splineOrder,
-        bias_maxIterations,
-        bias_fittingLevels,
-        bias_filterNoise,
-        bias_fwhm,
-        bias_otsuBins);
-
-      if (outputImage.IsNotNull())
-      {
-        updateProgress(80, "Saving file");
-        cbica::WriteImage< ImageTypeFloat2D >(outputImage, saveFileName_string);
-        if (cbica::fileExists(saveFileName_string))
-        {
-          updateProgress(90, "Displaying output");
-          LoadSlicerImages(saveFileName_string, CAPTK::ImageExtension::NIfTI);
-        }
-        updateProgress(0, "Bias correction finished");
-      }
-      else
-      {
         updateProgress(0, "Error in Bias correction!");
-      }
+    }
+    else if (!cbica::fileExists(saveFileName_string))
+    {
+        updateProgress(0, "Error saving Bias Correction output!");
     }
     else
     {
-      updateProgress(5, "Bias correction in process");
-
-      ImageTypeFloat3D::Pointer outputImage = biasCorrector.Run<ImageTypeFloat3D>(correctionType,
-        currentImage,
-        bias_splineOrder,
-        bias_maxIterations,
-        bias_fittingLevels,
-        bias_filterNoise,
-        bias_fwhm,
-        bias_otsuBins);
-
-      if (outputImage.IsNotNull())
-      {
-        updateProgress(80, "Saving file");
-        cbica::WriteImage< ImageTypeFloat3D >(outputImage, saveFileName_string);
-        if (cbica::fileExists(saveFileName_string))
-        {
-          updateProgress(90, "Displaying output");
-          LoadSlicerImages(saveFileName_string, CAPTK::ImageExtension::NIfTI);
-        }
+        updateProgress(90, "Displaying output");
+        LoadSlicerImages(saveFileName_string, CAPTK::ImageExtension::NIfTI);
         updateProgress(0, "Bias correction finished");
-      }
-      else
-      {
-        updateProgress(0, "Error in Bias correction!");
-      }
     }
+   
+    cbica::removeDir(tempDir);
+
   }
 }
 void fMainWindow::ImageRegistration()


### PR DESCRIPTION
Fixes#1243

## Proposed Changes
  - GUI BiasCorrection now invokes the preprocessing CLI with all the necessary parameters. This involves an intermediate image and duplicates the original image in memory and therefore some additional RAM is used, but it still runs in very reasonable time.
  - Fixed an unreported bug where the -fWHM option given to bias correction didn't accept floating point values, only integers.
  