### PR TITLE
Azure-based Docker build & push to Docker Hub repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -560,7 +560,22 @@ jobs:
         continueOnError: true
       displayName: Uploading to NITRC 
       condition: and( eq(variables['Build.DefinitionName'], 'CBICA.CaPTk'), or( eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'Schedule')) )
-
+        
+    - task: Docker@2
+    # Docker CLI needs to be installed on this agent for this step to work.
+      input:
+        containerRegistry: 'cbicaDockerHub' 
+        repository: 'cbica/captk'
+        command: buildAndPush
+        tags: |
+            latest
+            azure-latest
+            $(Build.BuildId)
+        Dockerfile: Dockerfile
+      displayName: Build and push image to Docker Hub
+      condition: and( eq(variables['Build.DefinitionName'], 'CBICA.CaPTk'), or( eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'Schedule')) )
+  
+    
 - job: 'macOS_SelfHost_1014'
   displayName: "Self-hosted agent on macOS 10.14"
   timeoutInMinutes: 0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -573,7 +573,7 @@ jobs:
             $(Build.BuildId)
         Dockerfile: Dockerfile
       displayName: Build and push image to Docker Hub
-      condition: and( eq(variables['Build.DefinitionName'], 'CBICA.CaPTk'), or( eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'Schedule')) )
+      #condition: and( eq(variables['Build.DefinitionName'], 'CBICA.CaPTk'), or( eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'Schedule')) )
   
     
 - job: 'macOS_SelfHost_1014'


### PR DESCRIPTION
Addresses #1344 

This now causes our self-hosted Linux build on Ubuntu 16.04 to build and push to the cbica/captk repo on Docker Hub.

I know that at this time the images built on 16.04 are displaying problems in Ubuntu 20.04 -- if we need to swap around the machines / agents used to do this build, we can.  

Note that this addition requires the Docker CLI, at least, to be installed on the relevant build agents. I've done this on ubuntu16.04-self-hosting in crete, and I've added the relevant information to the wiki.

This is a draft PR for now to check the builds on Azure -- I need to uncomment the conditional check before merging to master. Will ping the team when this is ready to be reviewed/merged.