### PR TITLE
Update Dockerfile to correct entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ ENV QT_X11_NO_MITSHM=1
 ENV QT_GRAPHICSSYSTEM="native"
 
 # define entry point
-ENTRYPOINT ["/CaPTk/bin/install/appdir/usr/bin/CaPTk"]
+ENTRYPOINT ["/work/CaPTk/bin/install/appdir/usr/bin/CaPTk"]


### PR DESCRIPTION
Entrypoint set in the dockerfile wasn't locatable because builds were being done in /work/CaPTk/bin rather than /CaPTk/bin. This was because in cbica/captk_centos7:devtoolset-4_superbuild, the working directory was set as /work.

Fixes #1427 