### PR TITLE
Diffusion derivatives additions

### DIFF
--- a/3_HowToGuides.txt
+++ b/3_HowToGuides.txt
@@ -982,7 +982,7 @@ References:
 
 /**
 \page Diffusion_Derivatives Miscellaneous: Diffusion Derivatives
-This application extracts various measurements from a Diffusion Weighted MRI scan. The exact measurements comprise i) fractional anisotropy (FA), ii) radial diffusivity (RAD), iii) axial diffusivity (AX), and iv) apparent diffusion coefficient (ADC).
+This application extracts various measurements from a Diffusion Weighted MRI scan. The exact measurements comprise i) fractional anisotropy (FA), ii) radial diffusivity (RAD), iii) axial diffusivity (AX), iv) apparent diffusion coefficient (ADC), and v) averaged b0 image (B0).
 
 This application is also available from the web on the [CBICA Image Processing Portal](https://ipp.cbica.upenn.edu/). Please see the experiment on the portal for details.
 
@@ -994,11 +994,12 @@ This application is also available from the web on the [CBICA Image Processing P
 <b> USAGE:</b>
 	-# Launch the application from "Applications" -> "Diffusion Derivatives".
 	-# Specify the paths to the input DW-MRI image, bval and bvec files with the gradient information, and the mask defining the voxels to extract the measurements.
+	-# If desired, enable registration of outputs and select a fixed image to register to.
 	-# Identify the diffusion measurements to be extracted, and the output directory.
 	-# Press the "Confirm" button.
 	-# The extracted measurements will be saved at the specified location (~5 minutes).
 \verbatim
-${CaPTk_InstallDir}/bin/ DiffusionDerivatives.exe -i C:/inputDWI.nii.gz -m C:/mask.nii.gz -b C:/input.bval -g C:/input.bvec -a 1 -f 1 -r 1 -t 1 -o C:/output
+${CaPTk_InstallDir}/bin/ DiffusionDerivatives.exe -i C:/inputDWI.nii.gz -m C:/mask.nii.gz -b C:/input.bval -g C:/input.bvec -a 1 -f 1 -r 1 -t 1 -z 1 -reg C:/template.nii.gz -o C:/output
 \endverbatim
 
 --------

--- a/src/applications/DiffusionDerivatives.cxx
+++ b/src/applications/DiffusionDerivatives.cxx
@@ -17,6 +17,7 @@ int main(int argc, char **argv)
   parser.addOptionalParameter("f", "fractional", cbica::Parameter::BOOLEAN, "", "Generate the Fractional Anisotropy image (1=YES, 0=NO, 1 (Default))");
   parser.addOptionalParameter("r", "radial", cbica::Parameter::BOOLEAN, "", "Generate the Radial Diffusivity image (1=YES, 0=NO, 1 (Default))");
   parser.addOptionalParameter("t", "coefficient", cbica::Parameter::BOOLEAN, "", "Generate the Apparent Diffusion Coefficient (1=YES, 0=NO, 1 (Default))");
+  parser.addOptionalParameter("z", "b0", cbica::Parameter::BOOLEAN, "", "Generate the b0 image (1=YES, 0=NO, 1 (Default))");
 
   parser.addRequiredParameter("o", "output", cbica::Parameter::STRING, "", "The output directory.");
   parser.addOptionalParameter("L", "Logger", cbica::Parameter::STRING, "log file which user has write access to", "Full path to log file to store console outputs", "By default, only console output is generated");
@@ -33,6 +34,7 @@ int main(int argc, char **argv)
   bool faPresent = 1;
   bool radPresent = 1;
   bool trPresent = 1;
+  bool bZeroPresent = 1;
 
   int tempPosition;
   std::string inputFileName, inputMaskName, inputBValName, inputBVecName, outputDirectoryName;
@@ -82,6 +84,10 @@ int main(int argc, char **argv)
   if (parser.compareParameter("t", tempPosition))
   {
     parser.getParameterValue("t", trPresent);
+  }
+  if (parser.compareParameter("z", tempPosition))
+  {
+      parser.getParameterValue("z", bZeroPresent);
   }
 
   if (parser.compareParameter("o", tempPosition))
@@ -135,6 +141,8 @@ int main(int argc, char **argv)
     cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[2], outputDirectoryName + "/RadialDiffusivity.nii.gz");
   if (axPresent == true)
     cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[3], outputDirectoryName + "/AxialDiffusivity.nii.gz");
+  if (bZeroPresent == true)
+      cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[4], outputDirectoryName + "/b0.nii.gz");
 
   std::cout << "Finished successfully.\n";
 

--- a/src/applications/DiffusionDerivatives.h
+++ b/src/applications/DiffusionDerivatives.h
@@ -815,7 +815,7 @@ std::vector<itk::Image<float, 3>::Pointer>  DiffusionDerivatives::dtiRecon(std::
     {
       allocateScalarIm<ScalarImageType, TensorImageType>(bZeroIm, tensorIm);
       typename InputImageType::RegionType inputRegion = img4D->GetLargestPossibleRegion();
-      InputImageType::SizeType desiredSize = inputRegion.GetSize();
+      typename InputImageType::SizeType desiredSize = inputRegion.GetSize();
       desiredSize[3] = 0; // We'll always collapse along the 4th dimension
 
       // Add all b0 together first to average the images
@@ -828,7 +828,7 @@ std::vector<itk::Image<float, 3>::Pointer>  DiffusionDerivatives::dtiRecon(std::
           typename InputImageType::IndexType index = inputRegion.GetIndex();
           index[3] = indexesWhereBValZero[i]; // Extract only the current time index
 
-          InputImageType::RegionType targetRegion;
+          typename InputImageType::RegionType targetRegion;
           targetRegion.SetSize(desiredSize);
           targetRegion.SetIndex(index);
 

--- a/src/applications/DiffusionDerivatives.h
+++ b/src/applications/DiffusionDerivatives.h
@@ -31,6 +31,7 @@ See COPYING file or https://www.med.upenn.edu/cbica/captk/license.html
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkNaryAddImageFilter.h"
+#include "itkMaskImageFilter.h"
 #include "itkDivideImageFilter.h"
 #include "cbicaLogging.h"
 #include "CaPTkDefines.h"

--- a/src/applications/DiffusionDerivatives.h
+++ b/src/applications/DiffusionDerivatives.h
@@ -848,7 +848,7 @@ std::vector<itk::Image<float, 3>::Pointer>  DiffusionDerivatives::dtiRecon(std::
       divider->Update();
 
       // Apply mask to the now-averaged b0
-      typedef itk::MaskImageFilter<ScalarImageType, ImageMaskType, ScalarImageType> MaskerType;
+      typedef typename itk::MaskImageFilter<ScalarImageType, ImageMaskType, ScalarImageType> MaskerType;
       typename MaskerType::Pointer masker = MaskerType::New();
       masker->SetInput(divider->GetOutput());
       masker->SetMaskImage(maskReader->GetOutput());

--- a/src/view/gui/fDiffusionMeasuresDialog.cpp
+++ b/src/view/gui/fDiffusionMeasuresDialog.cpp
@@ -18,7 +18,7 @@ fDiffusionEstimator::fDiffusionEstimator()
   connect(inputMaskButton, SIGNAL(clicked()), this, SLOT(OpenInputMaskImage()));
   connect(inputBvalButton, SIGNAL(clicked()), this, SLOT(OpenInputBValImage()));
   connect(inputBvecButton, SIGNAL(clicked()), this, SLOT(OpenInputBVecImage()));
-
+  connect(inputRegistrationButton, SIGNAL(clicked()), this, SLOT(OpenInputRegistrationImage()));
 
   connect(outputImageButton, SIGNAL(clicked()), this, SLOT(SelectOutputImage()));
 
@@ -60,20 +60,25 @@ void fDiffusionEstimator::ConfirmButtonPressed()
     ShowErrorMessage("Please specify the BVec file.", this);
     return;
   }
+  if (m_register->isChecked() && (inputRegistrationFile->text().isEmpty() || !cbica::isFile(inputRegistrationFile->text().toStdString())))
+  {
+      ShowErrorMessage("In order to register output, please specify a fixed image.", this);
+      return;
+  }
 	if (outputImageName->text().isEmpty())
 	{
     ShowErrorMessage("Please specify the output directory.", this);
 		return;
 	}
-  if (m_ax->isChecked() == false && m_fa->isChecked() == false && m_rad->isChecked() == false && m_tr->isChecked() == false)
+  if (!m_ax->isChecked() && !m_fa->isChecked() && !m_rad->isChecked() && !m_tr->isChecked() && !m_bzero->isChecked())
   {
-    ShowErrorMessage("Please select at least one of the given four options: Axial diffusivity, fractional anisotropy, radial diffusivity, apparant diffusion coefficient.");
+    ShowErrorMessage("Please select at least one of the given options: Axial diffusivity, fractional anisotropy, radial diffusivity, apparent diffusion coefficient, extract b0");
     return;
   }
   emit RunDiffusionMeasuresCalculation(mInputPathName.toStdString(), mInputMaskName.toStdString(),
       inputBvalName->text().toStdString(), inputBvecName->text().toStdString(),
       m_ax->isChecked(), m_fa->isChecked(), m_rad->isChecked(), m_tr->isChecked(), m_bzero->isChecked(),
-    mOutputPathName.toStdString());
+    mOutputPathName.toStdString(), m_register->isChecked(), mInputRegistrationFileName.toStdString());
 
 	this->close();
 }
@@ -120,6 +125,16 @@ void fDiffusionEstimator::OpenInputBVecImage()
 	else
 		inputBvecName->setText(inputImage);
 	mInputBVecName = inputImage;
+}
+
+void fDiffusionEstimator::OpenInputRegistrationImage()
+{
+    auto inputImage = getExistingFile(this, mInputRegistrationFileName, "*.nii.gz");
+    if (inputImage.isNull() || inputImage.isEmpty())
+        return;
+    else
+        inputRegistrationFile->setText(inputImage);
+    mInputRegistrationFileName = inputImage;
 }
 
 void fDiffusionEstimator::SelectOutputImage()

--- a/src/view/gui/fDiffusionMeasuresDialog.cpp
+++ b/src/view/gui/fDiffusionMeasuresDialog.cpp
@@ -26,6 +26,7 @@ fDiffusionEstimator::fDiffusionEstimator()
   m_fa->setChecked(true);
   m_rad->setChecked(true);
   m_tr->setChecked(true);
+  m_bzero->setChecked(true);
 }
 fDiffusionEstimator::~fDiffusionEstimator()
 {
@@ -69,9 +70,9 @@ void fDiffusionEstimator::ConfirmButtonPressed()
     ShowErrorMessage("Please select at least one of the given four options: Axial diffusivity, fractional anisotropy, radial diffusivity, apparant diffusion coefficient.");
     return;
   }
-	emit RunDiffusionMeasuresCalculation(mInputPathName.toStdString(), mInputMaskName.toStdString(),
-    inputBvalName->text().toStdString(), inputBvecName->text().toStdString(),
-    m_ax->isChecked(), m_fa->isChecked(), m_rad->isChecked(), m_tr->isChecked(),
+  emit RunDiffusionMeasuresCalculation(mInputPathName.toStdString(), mInputMaskName.toStdString(),
+      inputBvalName->text().toStdString(), inputBvecName->text().toStdString(),
+      m_ax->isChecked(), m_fa->isChecked(), m_rad->isChecked(), m_tr->isChecked(), m_bzero->isChecked(),
     mOutputPathName.toStdString());
 
 	this->close();

--- a/src/view/gui/fDiffusionMeasuresDialog.h
+++ b/src/view/gui/fDiffusionMeasuresDialog.h
@@ -58,7 +58,7 @@ public:
 
 signals:
 	void RunDiffusionMeasuresCalculation(const std::string inputImageFile, const std::string inputMaskFile,
-    const std::string bValFile, const std::string bVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const std::string outputFolder);
+    const std::string bValFile, const std::string bVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const bool bzero, const std::string outputFolder);
 };
 
 

--- a/src/view/gui/fDiffusionMeasuresDialog.h
+++ b/src/view/gui/fDiffusionMeasuresDialog.h
@@ -44,6 +44,7 @@ public:
 	QString mInputMaskName;
 	QString mInputBValName;
 	QString mInputBVecName;
+	QString mInputRegistrationFileName;
 	QString mOutputPathName;
 
 
@@ -54,11 +55,12 @@ public:
 	void OpenInputMaskImage();
 	void OpenInputBValImage();
 	void OpenInputBVecImage();
+	void OpenInputRegistrationImage();
 	void SelectOutputImage();
 
 signals:
 	void RunDiffusionMeasuresCalculation(const std::string inputImageFile, const std::string inputMaskFile,
-    const std::string bValFile, const std::string bVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const bool bzero, const std::string outputFolder);
+    const std::string bValFile, const std::string bVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const bool bzero, const std::string outputFolder, const bool registrationRequested, const std::string fixedImage);
 };
 
 

--- a/src/view/gui/fMainWindow.cpp
+++ b/src/view/gui/fMainWindow.cpp
@@ -908,8 +908,8 @@ fMainWindow::fMainWindow()
   connect(&perfalignPanel, SIGNAL(RunPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string)), this, SLOT(CallPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string)));
 
 
-  connect(&diffmeasuresPanel, SIGNAL(RunDiffusionMeasuresCalculation(const std::string, const std::string, const std::string, const std::string, const bool, const bool, const bool, const bool, const std::string)), this,
-    SLOT(CallDiffusionMeasuresCalculation(const std::string, const std::string, const std::string, const std::string, const bool, const bool, const bool, const bool, const std::string)));
+  connect(&diffmeasuresPanel, SIGNAL(RunDiffusionMeasuresCalculation(const std::string, const std::string, const std::string, const std::string, const bool, const bool, const bool, const bool, const bool, const std::string)), this,
+    SLOT(CallDiffusionMeasuresCalculation(const std::string, const std::string, const std::string, const std::string, const bool, const bool, const bool, const bool, const bool, const std::string)));
 
   connect(&whiteStripeNormalizer, SIGNAL(RunWhiteStripe(double, int, int, int, double, double, int, bool, const std::string)), this, SLOT(CallWhiteStripe(double, int, int, int, double, double, int, bool, const std::string)));
 
@@ -8990,7 +8990,7 @@ void fMainWindow::CallImageDeepMedicNormalizer(const std::string inputImage, con
   }
 }
 
-void fMainWindow::CallDiffusionMeasuresCalculation(const std::string inputImage, const std::string maskImage, const std::string BValFile, const std::string BVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const std::string outputFolder)
+void fMainWindow::CallDiffusionMeasuresCalculation(const std::string inputImage, const std::string maskImage, const std::string BValFile, const std::string BVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const bool bzero, const std::string outputFolder)
 {
   DiffusionDerivatives m_diffusionderivatives;
   typedef itk::Image<float, 3> ScalarImageType;
@@ -9026,7 +9026,8 @@ void fMainWindow::CallDiffusionMeasuresCalculation(const std::string inputImage,
     cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[2], outputFolder + "/RadialDiffusivity.nii.gz");
   if (ax == true)
     cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[3], outputFolder + "/AxialDiffusivity.nii.gz");
-
+  if (bzero == true)
+      cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[4], outputFolder + "/b0.nii.gz");
   QString msg;
   msg = "Diffusion derivatives have been saved at the specified locations.";
   ShowMessage(msg.toStdString(), this);

--- a/src/view/gui/fMainWindow.cpp
+++ b/src/view/gui/fMainWindow.cpp
@@ -908,8 +908,8 @@ fMainWindow::fMainWindow()
   connect(&perfalignPanel, SIGNAL(RunPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string)), this, SLOT(CallPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string)));
 
 
-  connect(&diffmeasuresPanel, SIGNAL(RunDiffusionMeasuresCalculation(const std::string, const std::string, const std::string, const std::string, const bool, const bool, const bool, const bool, const bool, const std::string)), this,
-    SLOT(CallDiffusionMeasuresCalculation(const std::string, const std::string, const std::string, const std::string, const bool, const bool, const bool, const bool, const bool, const std::string)));
+  connect(&diffmeasuresPanel, SIGNAL(RunDiffusionMeasuresCalculation(const std::string, const std::string, const std::string, const std::string, const bool, const bool, const bool, const bool, const bool, const std::string, const bool, const std::string)), this,
+    SLOT(CallDiffusionMeasuresCalculation(const std::string, const std::string, const std::string, const std::string, const bool, const bool, const bool, const bool, const bool, const std::string, const bool, const std::string)));
 
   connect(&whiteStripeNormalizer, SIGNAL(RunWhiteStripe(double, int, int, int, double, double, int, bool, const std::string)), this, SLOT(CallWhiteStripe(double, int, int, int, double, double, int, bool, const std::string)));
 
@@ -8990,7 +8990,7 @@ void fMainWindow::CallImageDeepMedicNormalizer(const std::string inputImage, con
   }
 }
 
-void fMainWindow::CallDiffusionMeasuresCalculation(const std::string inputImage, const std::string maskImage, const std::string BValFile, const std::string BVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const bool bzero, const std::string outputFolder)
+void fMainWindow::CallDiffusionMeasuresCalculation(const std::string inputImage, const std::string maskImage, const std::string BValFile, const std::string BVecFile, const bool axPresent, const bool faPresent, const bool radPresent, const bool trPresent, const bool bZeroPresent, const std::string outputFolder, const bool registrationRequested, const std::string inputRegistrationFile)
 {
   DiffusionDerivatives m_diffusionderivatives;
   typedef itk::Image<float, 3> ScalarImageType;
@@ -9017,20 +9017,115 @@ void fMainWindow::CallDiffusionMeasuresCalculation(const std::string inputImage,
     return;
   }
   diffusionDerivatives = m_diffusionderivatives.Run(inputImage, maskImage, BValFile, BVecFile, outputFolder);
-  //fa,tr, rad , ax
-  if (fa == true)
-    cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[0], outputFolder + "/FractionalAnisotropy.nii.gz");
-  if (tr == true)
-    cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[1], outputFolder + "/ApparentDiffusionCoefficient.nii.gz");
-  if (rad == true)
-    cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[2], outputFolder + "/RadialDiffusivity.nii.gz");
-  if (ax == true)
-    cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[3], outputFolder + "/AxialDiffusivity.nii.gz");
-  if (bzero == true)
-      cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[4], outputFolder + "/b0.nii.gz");
-  QString msg;
-  msg = "Diffusion derivatives have been saved at the specified locations.";
-  ShowMessage(msg.toStdString(), this);
+
+  if (registrationRequested)
+  {
+      if (faPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[0], outputFolder + "/unregistered_FractionalAnisotropy.nii.gz");
+      if (trPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[1], outputFolder + "/unregistered_ApparentDiffusionCoefficient.nii.gz");
+      if (radPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[2], outputFolder + "/unregistered_RadialDiffusivity.nii.gz");
+      if (axPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[3], outputFolder + "/unregistered_AxialDiffusivity.nii.gz");
+      if (bZeroPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[4], outputFolder + "/unregistered_b0.nii.gz");
+
+      std::string greedyPathAndDim = cbica::getExecutablePath() + "greedy" +
+#if WIN32
+          ".exe" +
+#endif
+          " -d " + std::to_string(TImageType::ImageDimension);
+      std::string fixedOptions = " -a -ia-image-centers -dof 6 -i " + inputRegistrationFile + " "; // force rigid registration only
+      std::string commandToCall;
+      std::vector<int> returnCodesFromGreedy;
+
+      // TODO (Alex): This needs to be done more dynamically
+      std::string specificParams;
+
+      // Create the intermediate transforms
+      specificParams = outputFolder + "/unregistered_FractionalAnisotropy.nii.gz" + " -o " + outputFolder + "/affine_FractionalAnisotropy.mat";
+      commandToCall = greedyPathAndDim + fixedOptions + specificParams;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+      specificParams = outputFolder + "/unregistered_ApparentDiffusionCoefficient.nii.gz" + " -o " + outputFolder + "/affine_ApparentDiffusionCoefficient.mat";
+      commandToCall = greedyPathAndDim + fixedOptions + specificParams;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+      specificParams = outputFolder + "/unregistered_RadialDiffusivity.nii.gz" + " -o " + outputFolder + "/affine_RadialDiffusivity.mat";
+      commandToCall = greedyPathAndDim + fixedOptions + specificParams;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+      specificParams = outputFolder + "/unregistered_AxialDiffusivity.nii.gz" + " -o " + outputFolder + "/affine_AxialDiffusivity.mat";
+      commandToCall = greedyPathAndDim + fixedOptions + specificParams;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+      specificParams = outputFolder + "/unregistered_b0.nii.gz" + " -o " + outputFolder + "/affine_b0.mat";
+      commandToCall = greedyPathAndDim + fixedOptions + specificParams;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+
+      for (unsigned int i = 0; i < returnCodesFromGreedy.size(); i++)
+      {
+          if (returnCodesFromGreedy[i] != 0)
+          {
+              std::cerr << "Something went wrong when generating transforms with Greedy.\n";
+              return;
+          }
+      }
+
+      returnCodesFromGreedy.clear();
+      // Now run the transform and image through greedy to produce actual output...
+      std::string fixedOptions2 = " -rf " + inputRegistrationFile + " -ri LINEAR -r ";
+
+      std::string specificParams2 = outputFolder + "/affine_FractionalAnisotropy.mat" +
+          " -rm " + outputFolder + "/unregistered_FractionalAnisotropy.nii.gz" +
+          " " + outputFolder + "/FractionalAnisotropy.nii.gz";
+      commandToCall = greedyPathAndDim + fixedOptions2 + specificParams2;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+      specificParams2 = outputFolder + "/affine_ApparentDiffusionCoefficient.mat" +
+          " -rm " + outputFolder + "/unregistered_ApparentDiffusionCoefficient.nii.gz" +
+          " " + outputFolder + "/ApparentDiffusionCoefficient.nii.gz";
+      commandToCall = greedyPathAndDim + fixedOptions2 + specificParams2;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+      specificParams2 = outputFolder + "/affine_RadialDiffusivity.mat" +
+          " -rm " + outputFolder + "/unregistered_RadialDiffusivity.nii.gz" +
+          " " + outputFolder + "/RadialDiffusivity.nii.gz";
+      commandToCall = greedyPathAndDim + fixedOptions2 + specificParams2;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+      specificParams2 = outputFolder + "/affine_AxialDiffusivity.mat" +
+          " -rm " + outputFolder + "/unregistered_AxialDiffusivity.nii.gz" +
+          " " + outputFolder + "/AxialDiffusivity.nii.gz";
+      commandToCall = greedyPathAndDim + fixedOptions2 + specificParams2;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+      specificParams2 = outputFolder + "/affine_b0.mat" +
+          " -rm " + outputFolder + "/unregistered_b0.nii.gz" +
+          " " + outputFolder + "/b0.nii.gz";
+      commandToCall = greedyPathAndDim + fixedOptions2 + specificParams2;
+      returnCodesFromGreedy.push_back(std::system(commandToCall.c_str()));
+
+      for (unsigned int i = 0; i < returnCodesFromGreedy.size(); i++)
+      {
+          if (returnCodesFromGreedy[i] != 0)
+          {
+              std::cerr << "Something went wrong when registering final output with Greedy.\n";
+              return;
+          }
+      }
+
+  }
+  else
+  {
+      std::cout << "Writing measures to the specified output directory.\n";
+      if (faPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[0], outputFolder + "/FractionalAnisotropy.nii.gz");
+      if (trPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[1], outputFolder + "/ApparentDiffusionCoefficient.nii.gz");
+      if (radPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[2], outputFolder + "/RadialDiffusivity.nii.gz");
+      if (axPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[3], outputFolder + "/AxialDiffusivity.nii.gz");
+      if (bZeroPresent == true)
+          cbica::WriteImage< ImageTypeFloat3D >(diffusionDerivatives[4], outputFolder + "/b0.nii.gz");
+  }
+
+  std::cout << "Finished successfully.\n";
+
 }
 void fMainWindow::CallPerfusionMeasuresCalculation(const bool rcbv, const bool  psr, const bool ph, const std::string inputfilename, std::string outputFolder)
 {

--- a/src/view/gui/fMainWindow.h
+++ b/src/view/gui/fMainWindow.h
@@ -803,9 +803,10 @@ public slots:
   \param FA Flag that enables FA calculation
   \param RAD Flag that enables RAD calculation
   \param TR Flag that enables TR calculation
+  \param BZero flag that enables averaged b0 image calculation 
   \param outputFolder The output folder to write all results
   */
-  void CallDiffusionMeasuresCalculation(const std::string inputImage, const std::string maskImage, const std::string BValFile, const std::string BVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const std::string outputFolder);
+  void CallDiffusionMeasuresCalculation(const std::string inputImage, const std::string maskImage, const std::string BValFile, const std::string BVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const bool bzero, const std::string outputFolder);
 
   /**
   \brief Call the Diffusion Measures application with the inputs

--- a/src/view/gui/fMainWindow.h
+++ b/src/view/gui/fMainWindow.h
@@ -806,7 +806,7 @@ public slots:
   \param BZero flag that enables averaged b0 image calculation 
   \param outputFolder The output folder to write all results
   */
-  void CallDiffusionMeasuresCalculation(const std::string inputImage, const std::string maskImage, const std::string BValFile, const std::string BVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const bool bzero, const std::string outputFolder);
+  void CallDiffusionMeasuresCalculation(const std::string inputImage, const std::string maskImage, const std::string BValFile, const std::string BVecFile, const bool ax, const bool fa, const bool rad, const bool tr, const bool bzero, const std::string outputFolder, const bool registrationRequested, const std::string registrationFixedImage);
 
   /**
   \brief Call the Diffusion Measures application with the inputs

--- a/src/view/gui/ui_fDiffusionMeasuresDialog.h
+++ b/src/view/gui/ui_fDiffusionMeasuresDialog.h
@@ -62,6 +62,11 @@ public:
 	QLineEdit	*inputBvecName;
 	QPushButton *inputBvecButton;
 
+	QLabel* registrationFileLabel;
+	QLineEdit* inputRegistrationFile;
+	QPushButton* inputRegistrationButton;
+
+
 	QGroupBox	*outputGroupBox;
 	QGridLayout *outputGridLayout;
 	QLineEdit	*outputImageName;
@@ -76,6 +81,7 @@ public:
 	QCheckBox* m_rad;
 	QCheckBox* m_tr;
 	QCheckBox* m_bzero;
+	QCheckBox* m_register;
 
 	QHBoxLayout * horizontalLayout;
 
@@ -169,6 +175,19 @@ public:
 		inputBvecButton->setObjectName(QString::fromUtf8("inputBvecButton"));
 		inputBvecButton->setText(QString("Browse"));
 
+		registrationFileLabel = new QLabel(inputGroupBox);
+		sizePolicy.setHeightForWidth(registrationFileLabel->sizePolicy().hasHeightForWidth());
+		registrationFileLabel->setSizePolicy(sizePolicy);
+
+		inputRegistrationFile = new QLineEdit("");
+		inputRegistrationFile->setObjectName(QString::fromUtf8("inputBvecName"));
+		sizePolicy.setHeightForWidth(inputRegistrationFile->sizePolicy().hasHeightForWidth());
+		inputRegistrationFile->setSizePolicy(sizePolicy);
+		inputRegistrationFile->setAlignment(Qt::AlignCenter | Qt::AlignTrailing | Qt::AlignVCenter);
+
+		inputRegistrationButton = new QPushButton(inputGroupBox);
+		inputRegistrationButton->setObjectName(QString::fromUtf8("inputRegistrationFile"));
+		inputRegistrationButton->setText(QString("Browse"));
 
 
 
@@ -183,6 +202,8 @@ public:
 		m_tr->setEnabled(true);
 		m_bzero = new QCheckBox("Extract averaged B0 image");
 		m_bzero->setEnabled(true);
+		m_register = new QCheckBox("Register output to a fixed image");
+		m_register->setEnabled(true);
 
 
 		inputGridLayout->addWidget(inputImageLabel, 0, 0, 1, 1);
@@ -201,12 +222,17 @@ public:
 		inputGridLayout->addWidget(inputBvecName, 3, 1, 1, 1);
 		inputGridLayout->addWidget(inputBvecButton, 3, 2, 1, 1);
 
+		//inputGridLayout->addWidget(registrationFileLabel, 4, 0, 1, 1);
+		inputGridLayout->addWidget(m_register, 4, 0, 1, 1);
+		inputGridLayout->addWidget(inputRegistrationFile, 4, 1, 1, 1);
+		inputGridLayout->addWidget(inputRegistrationButton, 4, 2, 1, 1);
 
-		inputGridLayout->addWidget(m_fa, 4, 0, 1, 1);
-		inputGridLayout->addWidget(m_rad, 5, 0, 1, 1);
-		inputGridLayout->addWidget(m_ax, 6, 0, 1, 1);
-		inputGridLayout->addWidget(m_tr, 7, 0, 1, 1);
-		inputGridLayout->addWidget(m_bzero, 8, 0, 1, 1);
+
+		inputGridLayout->addWidget(m_fa, 5, 0, 1, 1);
+		inputGridLayout->addWidget(m_rad, 6, 0, 1, 1);
+		inputGridLayout->addWidget(m_ax, 7, 0, 1, 1);
+		inputGridLayout->addWidget(m_tr, 8, 0, 1, 1);
+		inputGridLayout->addWidget(m_bzero, 9, 0, 1, 1);
 
 		// output
 		outputGroupBox = new QGroupBox(fDiffusionEstimator);

--- a/src/view/gui/ui_fDiffusionMeasuresDialog.h
+++ b/src/view/gui/ui_fDiffusionMeasuresDialog.h
@@ -75,6 +75,7 @@ public:
 	QCheckBox* m_fa;
 	QCheckBox* m_rad;
 	QCheckBox* m_tr;
+	QCheckBox* m_bzero;
 
 	QHBoxLayout * horizontalLayout;
 
@@ -180,6 +181,8 @@ public:
 		m_rad->setEnabled(true);
 		m_tr  = new QCheckBox("Apparent Diffusion Coefficient");
 		m_tr->setEnabled(true);
+		m_bzero = new QCheckBox("Extract averaged B0 image");
+		m_bzero->setEnabled(true);
 
 
 		inputGridLayout->addWidget(inputImageLabel, 0, 0, 1, 1);
@@ -203,6 +206,7 @@ public:
 		inputGridLayout->addWidget(m_rad, 5, 0, 1, 1);
 		inputGridLayout->addWidget(m_ax, 6, 0, 1, 1);
 		inputGridLayout->addWidget(m_tr, 7, 0, 1, 1);
+		inputGridLayout->addWidget(m_bzero, 8, 0, 1, 1);
 
 		// output
 		outputGroupBox = new QGroupBox(fDiffusionEstimator);
@@ -281,6 +285,7 @@ public:
 		m_ax->setText(QApplication::translate("fDiffusionEstimator", "Axial Diffusivity", 0));
 		m_rad->setText(QApplication::translate("fDiffusionEstimator", "Radial Diffusivity", 0));
 		m_tr->setText(QApplication::translate("fDiffusionEstimator", "Apparent Diffusion Coefficient", 0));
+		m_bzero->setText(QApplication::translate("fDiffusionEstimator", "Extract averaged b0 image", 0));
 
 		inputImageLabel->setText(QApplication::translate("fDiffusionEstimator", "DWI Image:", 0));
 		inputMaskLabel->setText(QApplication::translate("fDiffusionEstimator", "Mask:", 0));


### PR DESCRIPTION
Fixes #1451
Fixes #1449 

Adds functionality for extracting (averaged) b0 images from DWI, and for registering the output.
I'm not passing the mask to greedy because the images were already masked in DD, and because it was causing errors for me (and really weird output).