### PR TITLE
Perfusion Alignment, PCA and Derivatives measures

### DIFF
--- a/3_HowToGuides.txt
+++ b/3_HowToGuides.txt
@@ -1016,14 +1016,14 @@ This application does perfusion alignment of the input Dynamic-Susceptibility Co
 
 <b> USAGE:</b>
 	-# Launch the application from "Applications" -> "Perfusion Alignment".
-	-# Specify the input DSC-MRI image, T1 post-contrast image, time-resolution of the DSC-MRI scan in seconds (2 seconds), number of time-points before (b) and after (a) drop of the perfusion curve, and the output directory.
-	-# Specify the optional drop-scaling (-d in the command line) and standard-deviation threshold (-s in the command line) parameters
+	-# Specify the input DSC-MRI image, T1 post-contrast image, time-resolution of the DSC-MRI scan in seconds (t1, ex. 2 seconds), number of time-points before (t3) and after (t4) drop of the perfusion curve, and the output directory.
+	-# Optionally, specify the output repetition time (t2, default 1 second), intensity drop in mean curve inside the ROI (-s2 in the command line, default 100) and the maximum intensity before the drop in mean curve inside the ROI (-s1 in the command line, default 300) parameters
 	-# Press "Confirm" button.
-	-# The b+a+1 individual volumes of the aligned DSC-MRI image will be saved at the specified location (~5 minutes).
-	-# Outupt folder will contain the alighned perfusion image along with CSV files containing the original, truncated, revised and interpolated perfusion curve signals.
+	-# The individual volumes of the aligned DSC-MRI image will be saved at the specified location (~5 minutes).
+	-# Output folder will contain the alighed perfusion image along with CSV files containing the original, truncated, revised and interpolated perfusion curve signals.
   - This application is also available as a stand-alone CLI for data analysts to build pipelines around, using the following example command: 
 \verbatim
-${CaPTk_InstallDir}/bin/PerfusionAlignment.exe -i C:/InputImage/convertedNIfTIPerf_image.nii.gz -b 15 -a 17 -t 2 -s 10 -d 1 -o C:/InputImage_output
+${CaPTk_InstallDir}/bin/PerfusionAlignment.exe -i C:/InputImage/convertedNIfTIPerf_image.nii.gz -m brainMask.nii.gz -t1 2 -t3 15 -t4 30 -o C:/testPerf
 \endverbatim
 
 */

--- a/src/applications/PerfusionPCA.cxx
+++ b/src/applications/PerfusionPCA.cxx
@@ -130,9 +130,11 @@ int main(int argc, char **argv)
   //check if output dir exists
   if (!cbica::directoryExists(outputDirectoryName))
   {
-    if (!cbica::createDirectory(outputDirectoryName))
-      std::cout << "The output directory can not be created:" << outputDirectoryName << std::endl;
-    return EXIT_FAILURE;
+      if (!cbica::createDirectory(outputDirectoryName))
+      {
+          std::cout << "The output directory can not be created:" << outputDirectoryName << std::endl;
+          return EXIT_FAILURE;
+      }
   }
 
   PerfusionPCA object_pca; //pca algorithm object

--- a/src/view/gui/fMainWindow.cpp
+++ b/src/view/gui/fMainWindow.cpp
@@ -904,7 +904,7 @@ fMainWindow::fMainWindow()
   //connect(&pcaPanel, SIGNAL(RunPCAEstimation(const int, const std::string, const std::string)), this, SLOT(CallPCACalculation(const int, const std::string, const std::string)));
   //connect(&trainingPanel, SIGNAL(RunTrainingSimulation(TrainingModuleParameters)), this, SLOT(CallTrainingSimulation(const TrainingModuleParameters)));
 
-  connect(&perfmeasuresPanel, SIGNAL(RunPerfusionMeasuresCalculation(const bool, const bool, const bool, const std::string, const std::string)), this, SLOT(CallPerfusionMeasuresCalculation(const bool, const bool, const bool, const std::string, const std::string)));
+  connect(&perfmeasuresPanel, SIGNAL(RunPerfusionMeasuresCalculation(const bool, const bool, const bool, const int, const int, const int, const int, const std::string, const std::string)), this, SLOT(CallPerfusionMeasuresCalculation(const bool, const bool, const bool, const int, const int, const int, const int, const std::string, const std::string)));
   connect(&perfalignPanel, SIGNAL(RunPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string, const std::string)), this, SLOT(CallPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string, const std::string)));
 
 
@@ -9031,7 +9031,9 @@ void fMainWindow::CallDiffusionMeasuresCalculation(const std::string inputImage,
   msg = "Diffusion derivatives have been saved at the specified locations.";
   ShowMessage(msg.toStdString(), this);
 }
-void fMainWindow::CallPerfusionMeasuresCalculation(const bool rcbv, const bool  psr, const bool ph, const std::string inputfilename, std::string outputFolder)
+void fMainWindow::CallPerfusionMeasuresCalculation(const bool rcbv, const bool  psr, const bool ph,
+    const int baselineStart, const int baselineEnd, const int recoveryStart, const int recoveryEnd,
+    const std::string inputfilename, std::string outputFolder)
 {
   if (!cbica::isFile(inputfilename))
   {
@@ -9049,6 +9051,10 @@ void fMainWindow::CallPerfusionMeasuresCalculation(const bool rcbv, const bool  
   typedef ImageTypeFloat4D PerfusionImageType;
 
   PerfusionDerivatives m_perfusionderivatives;
+  m_perfusionderivatives.SetBaselineStartPercentage(baselineStart);
+  m_perfusionderivatives.SetBaselineEndPercentage(baselineEnd);
+  m_perfusionderivatives.SetRecoveryStartPercentage(recoveryStart);
+  m_perfusionderivatives.SetRecoveryEndPercentage(recoveryEnd);
   std::vector<typename ImageTypeFloat3D::Pointer> perfusionDerivatives = m_perfusionderivatives.Run<ImageTypeFloat3D, ImageTypeFloat4D>(inputfilename, rcbv, psr, ph, outputFolder);
 
   if (perfusionDerivatives.size() == 0)

--- a/src/view/gui/fMainWindow.cpp
+++ b/src/view/gui/fMainWindow.cpp
@@ -905,7 +905,7 @@ fMainWindow::fMainWindow()
   //connect(&trainingPanel, SIGNAL(RunTrainingSimulation(TrainingModuleParameters)), this, SLOT(CallTrainingSimulation(const TrainingModuleParameters)));
 
   connect(&perfmeasuresPanel, SIGNAL(RunPerfusionMeasuresCalculation(const bool, const bool, const bool, const std::string, const std::string)), this, SLOT(CallPerfusionMeasuresCalculation(const bool, const bool, const bool, const std::string, const std::string)));
-  connect(&perfalignPanel, SIGNAL(RunPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string)), this, SLOT(CallPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string)));
+  connect(&perfalignPanel, SIGNAL(RunPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string, const std::string)), this, SLOT(CallPerfusionAlignmentCalculation(double, double, int, int, int, int, const std::string, const std::string, const std::string)));
 
 
   connect(&diffmeasuresPanel, SIGNAL(RunDiffusionMeasuresCalculation(const std::string, const std::string, const std::string, const std::string, const bool, const bool, const bool, const bool, const std::string)), this,
@@ -9075,7 +9075,7 @@ void fMainWindow::CallPerfusionMeasuresCalculation(const bool rcbv, const bool  
 }
 
 
-void fMainWindow::CallPerfusionAlignmentCalculation(const double echotime, const double echotimeOutput, const int before, const int after, const int mean, const int scale, const std::string inputfilename, const std::string inputmaskname, std::string outputFolder)
+void fMainWindow::CallPerfusionAlignmentCalculation(const double echotime, const double echotimeOutput, const int before, const int after, const int mean, const int scale, const std::string inputfilename, const std::string inputmaskname, const std::string outputFolder)
 {
   if (!cbica::isFile(inputfilename))
   {

--- a/src/view/gui/fMainWindow.h
+++ b/src/view/gui/fMainWindow.h
@@ -790,7 +790,7 @@ public slots:
   \param inputfile The input DSC-MRI image
   \param outputFolder The output folder to write all results
   */
-  void CallPerfusionMeasuresCalculation(const bool rcbv, const bool psr, const bool ph, const std::string inputfile, const std::string outputFolder);
+  void CallPerfusionMeasuresCalculation(const bool rcbv, const bool psr, const bool ph, const int baselineStart, const int baselineEnd, const int recoveryStart, const int recoveryEnd, const std::string inputfile, const std::string outputFolder);
 
   /**
   \brief Call the Diffusion Measures application with the inputs

--- a/src/view/gui/fMainWindow.h
+++ b/src/view/gui/fMainWindow.h
@@ -778,7 +778,7 @@ public slots:
   \param inputfilename The input perfusion image file name
   \param outputFolder The output folder to write all results
   */
-  void CallPerfusionAlignmentCalculation(const double echotime, const double echotimeOutput, const int before, const int after, const int mean, const int scale, const std::string inputfilename, const std::string inputmaskname, std::string outputFolder);
+  void CallPerfusionAlignmentCalculation(const double echotime, const double echotimeOutput, const int before, const int after, const int mean, const int scale, const std::string inputfilename, const std::string inputmaskname, const std::string outputFolder);
 
   /**
   \brief Call the Perfusion Measures application with the inputs

--- a/src/view/gui/fPerfusionAlignmentDialog.cpp
+++ b/src/view/gui/fPerfusionAlignmentDialog.cpp
@@ -13,6 +13,7 @@ fPerfusionAligner::fPerfusionAligner()
   connect(confirmButton, SIGNAL(clicked()), this, SLOT(ConfirmButtonPressed()));
   connect(outputImageButton, SIGNAL(clicked()), this, SLOT(SelectOutputImage()));
   connect(inputImageButton, SIGNAL(clicked()), this, SLOT(SelectInputImage()));
+  connect(inputMaskButton, SIGNAL(clicked()), this, SLOT(SelectMaskImage()));
 }
 fPerfusionAligner::~fPerfusionAligner()
 {
@@ -84,4 +85,15 @@ void fPerfusionAligner::SelectInputImage()
 		inputImageName->setText(inputImage);
 
 	mInputPathName = inputImage;
+}
+
+void fPerfusionAligner::SelectMaskImage()
+{
+    auto maskImage = getExistingFile(this, mMaskPathName);
+    if (maskImage.isNull() || maskImage.isEmpty())
+        return;
+    else
+        inputMaskName->setText(maskImage);
+
+    mMaskPathName = maskImage;
 }

--- a/src/view/gui/fPerfusionAlignmentDialog.h
+++ b/src/view/gui/fPerfusionAlignmentDialog.h
@@ -50,7 +50,7 @@ public:
   void SelectInputImage();
 
 signals:
-  void RunPerfusionAlignmentCalculation(double echotime, double echoOutput, int before, int after, int mean, int scale, const std::string inputfile, const std::string maskfile, std::string outputFolder);
+  void RunPerfusionAlignmentCalculation(double echotime, double echoOutput, int before, int after, int mean, int scale, const std::string inputfile, const std::string maskfile, const std::string outputFolder);
 };
 
 

--- a/src/view/gui/fPerfusionAlignmentDialog.h
+++ b/src/view/gui/fPerfusionAlignmentDialog.h
@@ -42,12 +42,14 @@ public:
 
   QString mInputPathName;
   QString mOutputPathName;
+  QString mMaskPathName;
 
   public slots:
   void CancelButtonPressed();
   void ConfirmButtonPressed();
   void SelectOutputImage();
   void SelectInputImage();
+  void SelectMaskImage();
 
 signals:
   void RunPerfusionAlignmentCalculation(double echotime, double echoOutput, int before, int after, int mean, int scale, const std::string inputfile, const std::string maskfile, const std::string outputFolder);

--- a/src/view/gui/fPerfusionMeasuresDialog.cpp
+++ b/src/view/gui/fPerfusionMeasuresDialog.cpp
@@ -16,6 +16,10 @@ fPerfusionEstimator::fPerfusionEstimator()
   m_baselineEnd->setValue(20);
   m_recoveryStart->setValue(66);
   m_recoveryEnd->setValue(88);
+  m_baselineStart->setEnabled(true);
+  m_baselineEnd->setEnabled(true);
+  m_recoveryStart->setEnabled(true);
+  m_recoveryEnd->setEnabled(true);
 
   m_baselineStartLabel->setText("Baseline Start Threshold %");
   m_baselineEndLabel->setText("Baseline End Threshold %");
@@ -55,7 +59,12 @@ void fPerfusionEstimator::ConfirmButtonPressed()
     ShowErrorMessage("Please select at least one of the given three options: ap-rCBV, PH, PSR.");
     return;
   }
-  emit RunPerfusionMeasuresCalculation(m_rcbv->isChecked(), m_psr->isChecked(), m_ph->isChecked(), mInputPathName.toStdString(), mOutputPathName.toStdString());
+  if (m_baselineStart->value() >= m_baselineEnd->value() || m_recoveryStart->value() >= m_recoveryEnd->value() || m_baselineEnd->value() >= m_recoveryStart->value())
+  {
+    ShowErrorMessage("Please check your baseline and recovery thresholds for validity.");
+    return;
+  }
+  emit RunPerfusionMeasuresCalculation(m_rcbv->isChecked(), m_psr->isChecked(), m_ph->isChecked(), m_baselineStart->value(), m_baselineEnd->value(), m_recoveryStart->value(), m_recoveryEnd->value(), mInputPathName.toStdString(), mOutputPathName.toStdString());
 
   this->close();
 }

--- a/src/view/gui/fPerfusionMeasuresDialog.h
+++ b/src/view/gui/fPerfusionMeasuresDialog.h
@@ -51,7 +51,10 @@ public:
   void SelectInputImage();
 
 signals:
-  void RunPerfusionMeasuresCalculation(const bool rcbv, const bool psr,const bool ph, const std::string inputfile,  std::string outputFolder);
+  void RunPerfusionMeasuresCalculation(const bool rcbv, const bool psr,const bool ph, 
+      const int baselineStartThreshold, const int baselineEndThreshold,
+      const int recoveryStartThreshold, const int recoveryEndThreshold,
+      const std::string inputfile, std::string outputFolder);
 };
 
 

--- a/src/view/gui/ui_fPerfusionAlignmentDialog.h
+++ b/src/view/gui/ui_fPerfusionAlignmentDialog.h
@@ -268,7 +268,7 @@ public:
     // m_psr->setText(QApplication::translate("fPerfusionAlignmentDialog", "Percent Signal Recovery", 0, QApplication::UnicodeUTF8));
     // m_ph->setText(QApplication::translate("fPerfusionAlignmentDialog", "Peak Height", 0, QApplication::UnicodeUTF8));
     // NEW CHANGES
-    fPerfusionAlignmentDialog->setWindowTitle(QApplication::translate("fPerfusionAlignmentDialog", "Perfusion Derivatives", 0));
+    fPerfusionAlignmentDialog->setWindowTitle(QApplication::translate("fPerfusionAlignmentDialog", "Perfusion Alignment", 0));
     inputBeforePointsLabel->setText(QApplication::translate("fPerfusionAlignmentDialog", "# of Points before drop", 0));
     inputAfterPointsLabel->setText(QApplication::translate("fPerfusionAlignmentDialog", "# of Points after drop", 0));
     inputEchoTimeLabel->setText(QApplication::translate("fPerfusionAlignmentDialog", "Time-resolution (seconds)", 0));

--- a/src/view/gui/ui_fPerfusionMeasuresDialog.h
+++ b/src/view/gui/ui_fPerfusionMeasuresDialog.h
@@ -142,15 +142,27 @@ public:
 	frame->setObjectName(QStringLiteral("frame"));
 	frame->setFrameShape(QFrame::StyledPanel);
 	frame->setFrameShadow(QFrame::Raised);
-	frame->setDisabled(true);
-	frame->setToolTip("Please use the CLI to adjust baseline and recovery thresholds.");
+	//frame->setDisabled(true);
+	//frame->setToolTip("Please use the CLI to adjust baseline and recovery thresholds.");
 
 	frameGridLayout = new QGridLayout(frame);
 
 	m_baselineStart = new QSpinBox(frame);
+    m_baselineStart->setEnabled(true);
+    m_baselineStart->setMinimum(0);
+    m_baselineStart->setMaximum(100);
 	m_baselineEnd = new QSpinBox(frame);
+    m_baselineEnd->setEnabled(true);
+    m_baselineEnd->setMinimum(0);
+    m_baselineEnd->setMaximum(100);
 	m_recoveryStart = new QSpinBox(frame);
+    m_recoveryStart->setEnabled(true);
+    m_recoveryStart->setMinimum(0);
+    m_recoveryStart->setMaximum(100);
 	m_recoveryEnd = new QSpinBox(frame);
+    m_recoveryEnd->setEnabled(true);
+    m_recoveryEnd->setMinimum(0);
+    m_recoveryEnd->setMaximum(100);
 
 	m_baselineStartLabel = new QLabel(frame);
 	m_baselineEndLabel = new QLabel(frame);


### PR DESCRIPTION
The following issues are addressed in this PR:
Fixes #1460 
Fixes #1459 
Fixes #1458 

I also:
changed Perfusion Alignment's HowTo guide to reflect the new usage.
fixed Perfusion Alignment's mask browse button which wasn't working.
changed a misleading dialog title in perfusion alignment.

To summarize: Perfusion Alignment signal/slot was re connected so that it runs from the GUI.
PerfusionDerivatives had elements re-enabled and now actually passes the threshold values (with a simple check for validity too). Fixed early return in PerfusionPCA.