### PR TITLE
GitHub Action:  create Docker image + upload to Hub

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag cbica/captk:$(date +%s)


### PR DESCRIPTION
This PR adds a GitHub action workflow that allows us to create a Docker image from master. This can be merged before or after the 1.9.0.Beta version change PR, doesn't matter.