### PR TITLE
Update to 1.9.0, also Fix ROI orientation, especially 4D

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ SET( ${PROJECT_NAME}_Variant "Full" ) # the particular variant of CaPTk (Full/Ne
 
 SET( PROJECT_VERSION_MAJOR 1 )
 SET( PROJECT_VERSION_MINOR 9 )
-SET( PROJECT_VERSION_PATCH 0.RC )
+SET( PROJECT_VERSION_PATCH 0 )
 SET( PROJECT_VERSION_TWEAK ) 
 
 # check for the string "nonRelease" in the PROJECT_VERSION_PATCH variable

--- a/Readme.md
+++ b/Readme.md
@@ -37,14 +37,13 @@ This work is in part supported by the grant U24-CA189523, awarded by the Nationa
 
 By downloading CaPTk, you agree to our [License](./LICENSE). You can review Installation Instructions [here](https://cbica.github.io/CaPTk/Installation.html).
 
-## Latest Stable (1.8.1)
+## Latest Stable (1.9.0)
 
 | Platform (x64) | Link                                             |
 |:--------------:|:------------------------------------------------:|
-| Windows        | https://www.nitrc.org/frs/downloadlink.php/11777 |
-| Linux          | https://www.nitrc.org/frs/downloadlink.php/11778 |
-| Linux (CentOS7)| https://www.nitrc.org/frs/downloadlink.php/11779 |
-| macOS          | https://www.nitrc.org/frs/downloadlink.php/11780 |
+| Windows        | https://www.nitrc.org/frs/downloadlink.php/12727 |
+| Linux          | https://www.nitrc.org/frs/downloadlink.php/12726 |
+
 
 ## Development Builds
 

--- a/docs/1_credits.html
+++ b/docs/1_credits.html
@@ -12,7 +12,7 @@
 		<br>
 		<img src="functionalityRepresentation.png"></center>
 		<br>
-		Cancer Imaging Phenomics Toolkit (CaPTk) v.1.9.0.RC &emsp;|&emsp;<b>Contact:</b> software@cbica.upenn.edu
+		Cancer Imaging Phenomics Toolkit (CaPTk) v.1.9.0 &emsp;|&emsp;<b>Contact:</b> software@cbica.upenn.edu
 		<br>
 		<b>Disclaimer:</b> CaPTk has been designed for non-commercial research purposes only and has not been reviewed or approved by the Food and Drug Administration (FDA). It is not intended or recommended for clinical application.
 		<br>

--- a/docs/BraTS_Metrics.html
+++ b/docs/BraTS_Metrics.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/BreastCancer_LIBRA.html
+++ b/docs/BreastCancer_LIBRA.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/BreastCancer_breastSegmentation.html
+++ b/docs/BreastCancer_breastSegmentation.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/BreastCancer_texture.html
+++ b/docs/BreastCancer_texture.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Diffusion_Derivatives.html
+++ b/docs/Diffusion_Derivatives.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Download.html
+++ b/docs/Download.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/FAQ.html
+++ b/docs/FAQ.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Getting_Started.html
+++ b/docs/Getting_Started.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Glioblastoma_Atlas.html
+++ b/docs/Glioblastoma_Atlas.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Glioblastoma_Confetti.html
+++ b/docs/Glioblastoma_Confetti.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Glioblastoma_Directionality.html
+++ b/docs/Glioblastoma_Directionality.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Glioblastoma_EGFRvIII.html
+++ b/docs/Glioblastoma_EGFRvIII.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Glioblastoma_PHI.html
+++ b/docs/Glioblastoma_PHI.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Glioblastoma_Pseudoprogression.html
+++ b/docs/Glioblastoma_Pseudoprogression.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Glioblastoma_Recurrence.html
+++ b/docs/Glioblastoma_Recurrence.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Glioblastoma_Survival.html
+++ b/docs/Glioblastoma_Survival.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Glioblastoma_WhiteStripe.html
+++ b/docs/Glioblastoma_WhiteStripe.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/How_To_Guides.html
+++ b/docs/How_To_Guides.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/ITCR_Connectivity.html
+++ b/docs/ITCR_Connectivity.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Installation.html
+++ b/docs/Installation.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/LungCancer_SBRT.html
+++ b/docs/LungCancer_SBRT.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/PCA_Extraction.html
+++ b/docs/PCA_Extraction.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/People.html
+++ b/docs/People.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Perfusion_Alignment.html
+++ b/docs/Perfusion_Alignment.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Perfusion_Derivatives.html
+++ b/docs/Perfusion_Derivatives.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/ReleaseNotes.html
+++ b/docs/ReleaseNotes.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Science.html
+++ b/docs/Science.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Technical_Reference.html
+++ b/docs/Technical_Reference.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/Training_Module.html
+++ b/docs/Training_Module.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/ht_FeatureExtraction.html
+++ b/docs/ht_FeatureExtraction.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/ht_Preprocessing.html
+++ b/docs/ht_Preprocessing.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/ht_Segmentation.html
+++ b/docs/ht_Segmentation.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/ht_SpecialApps.html
+++ b/docs/ht_SpecialApps.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/ht_utilities.html
+++ b/docs/ht_utilities.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/index.qhp
+++ b/docs/index.qhp
@@ -5,7 +5,7 @@
   <filterSection>
     <filterAttribute>doxygen</filterAttribute>
     <toc>
-      <section title="Cancer Imaging Phenomics Toolkit (CaPTk) 1.9.0.RC" ref="index.html">
+      <section title="Cancer Imaging Phenomics Toolkit (CaPTk) 1.9.0" ref="index.html">
         <section title="Overview" ref="index.html">
           <section title="Bug Tracker and Feature Request" ref="index.html#autotoc_md103" />
           <section title="Frequently Asked Questions (FAQ)" ref="index.html#autotoc_md104" />

--- a/docs/pages.html
+++ b/docs/pages.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/preprocessing_bias.html
+++ b/docs/preprocessing_bias.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/preprocessing_brats.html
+++ b/docs/preprocessing_brats.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/preprocessing_dcm2nii.html
+++ b/docs/preprocessing_dcm2nii.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/preprocessing_histoMatch.html
+++ b/docs/preprocessing_histoMatch.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/preprocessing_reg.html
+++ b/docs/preprocessing_reg.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/preprocessing_susan.html
+++ b/docs/preprocessing_susan.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/preprocessing_zScoreNorm.html
+++ b/docs/preprocessing_zScoreNorm.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/seg_DL.html
+++ b/docs/seg_DL.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/seg_GeoTrain.html
+++ b/docs/seg_GeoTrain.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/seg_Geodesic.html
+++ b/docs/seg_Geodesic.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/seg_SNAP.html
+++ b/docs/seg_SNAP.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/tr_FeatureExtraction.html
+++ b/docs/tr_FeatureExtraction.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/docs/tr_integration.html
+++ b/docs/tr_integration.html
@@ -30,7 +30,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">Cancer Imaging Phenomics Toolkit (CaPTk)
-   &#160;<span id="projectnumber">1.9.0.RC</span>
+   &#160;<span id="projectnumber">1.9.0</span>
    </div>
   </td>
  </tr>

--- a/src/cbica_toolkit/src/cbicaITKSafeImageIO.h
+++ b/src/cbica_toolkit/src/cbicaITKSafeImageIO.h
@@ -435,6 +435,7 @@ namespace cbica
   template <typename ComputedImageType = ImageTypeFloat3D, typename ExpectedImageType = ComputedImageType>
   void WriteImage(typename ComputedImageType::Pointer imageToWrite, const std::string &fileName)
   {
+    // TODO: Enable 4D image saving
     //// check write access
     //if (((_access(fileName.c_str(), 2)) == -1) || ((_access(fileName.c_str(), 6)) == -1))
     //{

--- a/src/cbica_toolkit/src/cbicaITKUtilities.h
+++ b/src/cbica_toolkit/src/cbicaITKUtilities.h
@@ -542,7 +542,7 @@ namespace cbica
     auto imageOrigin2 = imageInfo2.GetImageOrigins();
 
     auto imageDirs1 = imageInfo1.GetImageDirections();
-    auto imageDirs2 = imageInfo1.GetImageDirections();
+    auto imageDirs2 = imageInfo2.GetImageDirections();
 
     for (size_t d = 0; d < dims; d++)
     {
@@ -572,14 +572,15 @@ namespace cbica
         return false;
       }
 
-      if (imageDirs1[d].size() != imageDirs2[d].size())
+      if ( (imageDirs1[d].size() != imageDirs2[d].size()) && !FourDImageCheck )
       {
+        // Handle mis-matched dir sizes (generally indicates mismatch in dims)
         std::cout << "The direction in dimension[" << d << "] of the image_1 (" << image1 << ") and image_2 (" << image2 << ") doesn't match.\n";
         return false;
       }
       else
       {
-        for (size_t i = 0; i < imageDirs1[d].size(); i++)
+        for (size_t i = 0; i < dims; i++) // Dirs are NxN where N is dimensionality. We need to handle 4D vs 3D
         {
           if (imageDirs1[d][i] != imageDirs2[d][i])
           {

--- a/src/view/gui/SlicerManager.cpp
+++ b/src/view/gui/SlicerManager.cpp
@@ -138,14 +138,13 @@ void SlicerManager::SetPerfImage(ImageTypeFloat4D::Pointer image)
   filter->SetInput(mPerfusionImagePointer);
   filter->SetDirectionCollapseToSubmatrix(); // This is required.
   filter->Update();
-  typedef itk::OrientImageFilter< ImageTypeFloat3D, ImageTypeFloat3D > ReorientType;
-  auto reorienter = ReorientType::New();
-  reorienter->SetInput(filter->GetOutput());
-  reorienter->SetDesiredCoordinateOrientation(itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI);
-  reorienter->UseImageDirectionOn();
-  reorienter->Update();
-  mITKImage = reorienter->GetOutput();
+  mITKImage = cbica::GetImageOrientation(filter->GetOutput(),"RAI").second;
   UpdateVtkImage();
+}
+
+ImageTypeFloat4D::Pointer SlicerManager::GetPerfImage()
+{
+    return mPerfusionImagePointer;
 }
 
 void SlicerManager::SetOriginalOrigin(ImageTypeFloat3D::PointType origin)
@@ -1263,13 +1262,7 @@ void SlicerManager::Get3DImageAtCurrentPerfusionIndex(int sliderindex)
   croppingFilter->SetExtractionRegion(regionToCrop);
   croppingFilter->SetDirectionCollapseToSubmatrix(); // This is required.
   croppingFilter->Update();
-  typedef itk::OrientImageFilter< ImageTypeFloat3D, ImageTypeFloat3D > ReorientType;
-  auto reorienter = ReorientType::New();
-  reorienter->SetInput(croppingFilter->GetOutput());
-  reorienter->SetDesiredCoordinateOrientation(itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI);
-  reorienter->UseImageDirectionOn();
-  reorienter->Update();
-  mITKImage->Graft(reorienter->GetOutput());//TBD this is crashing 
+  mITKImage->Graft(cbica::GetImageOrientation(croppingFilter->GetOutput(), "RAI").second);
  
   UpdateVtkImage();
   this->Render();

--- a/src/view/gui/SlicerManager.h
+++ b/src/view/gui/SlicerManager.h
@@ -106,6 +106,10 @@ public:
   //! Set new 4D image 
   void SetPerfImage(ImageTypeFloat4D::Pointer image);
 
+  //! Get the loaded 4D image
+  ImageTypeFloat4D::Pointer GetPerfImage();
+
+
   //! Set the vtk mask
   void SetMask(vtkSmartPointer< vtkImageData >  mask);
 

--- a/src/view/gui/fMainWindow.cpp
+++ b/src/view/gui/fMainWindow.cpp
@@ -1320,20 +1320,8 @@ void fMainWindow::SaveImage_withFile(int indexOfInputImageToWrite, QString saveF
     }
     else if (cbica::ImageInfo(mSlicerManagers[index]->GetPathFileName()).GetImageDimensions() == 4)
     {
-        // TODO: uncomment the below for saving 4D images
-        /*
-        auto reorientedImage4D = cbica::GetImageOrientation< ImageTypeFloat4D >(convertVtkToItk<ImageTypeFloat4D::PixelType, ImageTypeFloat4D::ImageDimension>(mSlicerManagers[index]->mImage), originalOrientation);
-        auto img = reorientedImage.second;
-        auto infoChanger = itk::ChangeInformationImageFilter< ImageType >::New();
-        infoChanger->SetInput(img);
-        infoChanger->ChangeDirectionOn();
-        infoChanger->ChangeOriginOn();
-        infoChanger->SetOutputDirection(originalDirection);
-        infoChanger->SetOutputOrigin(originalOrigin);
-        infoChanger->Update();
-
-        cbica::WriteImage< ImageTypeFloat4D >(infoChanger->GetOutput(), correctExtension(saveFileName_string));
-        */
+        cbica::WriteImage< ImageTypeFloat4D >(mSlicerManagers[index]->GetPerfImage(), correctExtension(saveFileName_string));
+        updateProgress(0, "Image saved! (" + saveFileName_string + ")");
     }
     else
     {
@@ -1505,11 +1493,6 @@ void fMainWindow::SaveImage()
   int index = GetSlicerIndexFromItem(items[0]);
   if (index < 0 || index >= (int)mSlicerManagers.size()) 
   {
-    return;
-  }
-  if (cbica::ImageInfo(mSlicerManagers[index]->GetPathFileName()).GetImageDimensions() == 4)
-  {
-      ShowErrorMessage("Saving of 4D images is not currently supported. Please note that you may save a 3D mask/ROI file for a 4D image volume.");
     return;
   }
 


### PR DESCRIPTION
Updates to 1.9.0 as well to avoid needing multiple PRs.

ROIs were failing to load properly under certain conditions due to how images get reoriented for display and the incomplete tracking of original direction. This has been fixed in this PR. Now images/ROIs get reoriented into a common orientation when loaded into the viewer and reoriented back when saved -- so the ROI/Images will now render properly when loaded into, say, ITK-snap.


Basically, this fixes ROI and image orientation so that we properly track original orientation/direction/origin at load time and go back when saving under all conditions. Before this fix, ROIs were being saved with the "correct" directionality/orientation (the same as the image that was loaded), but the actual ROI data would not be aligned with this. So you'd get odd behavior like drawing on the image, saving it and reloading it to find that it was flipped. And when this wasn't tracked properly for 4D images, we ended up with a scenario where moving the 4D slider generated a change in the mask directionality.

This also prevents a crash from occurring when trying to save 4D images, but does not yet implement it (since it's not that useful -- we don't have anything that produces new 4D images right now, anyway). It also fixes a bug where certain ImageSanityChecks would fail between otherwise valid 4D and 3D images, and where mask saving/loading would sometimes fail for 2D images.

Relevant code is in fMainWindow.cpp, SlicerManager.cpp, and cbicaITKUtilities.cpp.

