### PR TITLE
Update cv command

### DIFF
--- a/docs/ht_utilities.html
+++ b/docs/ht_utilities.html
@@ -73,7 +73,7 @@ ${CaPTk_InstallDir}/bin/Utilities.exe -i C:/test/inputMask.nii.gz -o C:/outputMa
 <li>Image information <pre class="fragment">${CaPTk_InstallDir}/bin/Utilities.exe -i C:/test.nii.gz -inf
 ${CaPTk_InstallDir}/bin/Utilities.exe -i C:/test/1.dcm -inf</pre></li>
 <li>Unique values in image <pre class="fragment">${CaPTk_InstallDir}/bin/Utilities.exe -i C:/test/1.dcm -un</pre></li>
-<li>Change values in image: The following command will change all voxels of value 1 &amp; 2 to 2 &amp; 4, respectively: <pre class="fragment">${CaPTk_InstallDir}/bin/Utilities.exe -i C:/test/1.dcm -cv 1x2,2x4</pre></li>
+<li>Change values in image: The following command will change all voxels of value 1 &amp; 2 to 2 &amp; 4, respectively: <pre class="fragment">${CaPTk_InstallDir}/bin/Utilities.exe -i C:/test/1.dcm -o C:/test.nii.gz -cv 1x2,2x4</pre></li>
 <li>Get smallest bounding box in mask (optional isotropic bounding box) <pre class="fragment">${CaPTk_InstallDir}/bin/Utilities.exe -i C:/test/1.dcm -b C:/testMask.nii.gz -o C:/output.nii.gz</pre></li>
 <li>Test 2 images <pre class="fragment">${CaPTk_InstallDir}/bin/Utilities.exe -i C:/test/1.dcm -tb C:/test.nii.gz</pre></li>
 <li>Create mask from threshold <pre class="fragment">${CaPTk_InstallDir}/bin/Utilities.exe -i C:/test/1.dcm -o C:/test.nii.gz -cm 50,1000</pre></li>

--- a/src/applications/Utilities/src/Utilities.cxx
+++ b/src/applications/Utilities/src/Utilities.cxx
@@ -559,7 +559,7 @@ int algorithmsRunner()
   {
     auto outputImage = cbica::ChangeImageValues< TImageType >(cbica::ReadImage< TImageType >(inputImageFile), changeOldValues, changeNewValues);
 
-    if (!outputImage.IsNull())
+    if (!outputImage.IsNull() && !outputImageFile.empty())
     {
       cbica::WriteImage< TImageType >(outputImage, outputImageFile);
       std::cout << "Create Mask completed.\n";


### PR DESCRIPTION
## Proposed Changes
  - adding the required `-o <output image>` to the `-cv` command example on the docs
  - only print the success message if an updated image is successful and an output image filename is provided
  

## Additional Context

Currently, when I use the -cv command without specifying an output image name, I get a ImageFileWriter error as well as a misleading success message, e.g.

```
$ captk -i Downloads/BraTS2021_00001.nii.gz -cv 4,3
Error occurred while trying to write the image '': /usr/local/vsts/_work/1/s/bin/ITK-source/Modules/IO/ImageBase/include/itkImageFileWriter.hxx:123:
itk::ERROR: ImageFileWriter(0x7fb2c5104d50): No filename was specified
Create Mask completed.
``` 